### PR TITLE
Dreamcast Netplay wizard + pre-launch options editor

### DIFF
--- a/DEV_CHECKLIST.md
+++ b/DEV_CHECKLIST.md
@@ -18,8 +18,12 @@ rewritten DC.pak `launch.sh`) are built, compile clean on both platforms, and st
 (not committed). This supersedes the shell-based overlay-toggle flow entirely — see
 `workspace/all/other/flycast/README.md`'s Netplay chapter for what changed and why, and
 `docs/superpowers/specs/2026-07-29-netplay-prelaunch-wizard-design.md` for the design.
-**None of it has been run on real hardware yet** — every item below is a pending
-device check, not a regression from something that used to pass.
+**Verified 2026-07-29/30 on tg5040 Brick** (WiFi pairing + session in real use; solo
+failure-path pass over adb: rc contracts — no `--game` rc=2, `--cleanup` no-op rc=0 —
+first-screen cancel, hotspot AP up/`NextUI-<code>`/teardown-on-cancel within budget,
+kill-and-heal of an orphaned AP healed instantly, migration guard rewrote planted
+`GGPO=yes`/`device2=0`, `emu.cfg` md5 stable across all cancels). What remains below is
+the two-device pair matrix and its bundled checks.
 
 Shape of the shipped feature: `Y` on a netplay-capable ROM (Phase 1: DC.pak only,
 marked by a `netplay` file beside its `launch.sh`) writes `/tmp/netplay_launch` and
@@ -37,24 +41,12 @@ restores prior WiFi, stops a stray rsyncd, and removes the session file, bounded
 
 ### On-device verification
 
-- [ ] **Wizard solo, one device (Task 1/2/3/6 bring-up)**
-      — marker present/absent correctly gates the Y hint, the Y branch, and the
-      "Launch with Netplay" context item (present in ROM listings; per Task 1's own
-      notes, unreachable from the context menu at root, though Y itself works there);
-      Y writes `/tmp/netplay_launch` and launches exactly like an A press otherwise;
-      `START` opens root Search where `Y` used to.
-      Every wizard screen renders and `B` backs out one step at a time; `B` on the
-      very first screen exits the wizard (rc=1) and `launch.sh` returns to the game
-      list without ever starting flycast. Invoking `netplay.elf` with no `--game`
-      exits rc=2; `--cleanup` with no session file present is a harmless no-op (rc=0).
-      Hotspot host brings up `NextUI-<code>` and it is joinable from a second device
-      (or a phone); the WiFi picker scans and connects on a real LAN (not just the
-      bench fake-peer rig); a wrong password, then `B`, leaves other networks still
-      selectable. A stale session file left by a simulated kill is healed (hotspot
-      torn down / WiFi restored) before the wizard's very first menu appears.
 - [ ] **Pair test, Brick ↔ Smart Pro S, a netplay-capable DC game (e.g. MvC2), all
-      four quadrants** (host/client × hotspot/WiFi) — from the spec's hardware
-      verification plan plus Task 4/5/7's device items:
+      four quadrants** (host/client × hotspot/WiFi) — *WiFi pairing + a full session
+      already proven in real use 2026-07-29/30; still open: the hotspot quadrants, the
+      mismatch `REJECT`, the save-sync integrity checks, the post-session port sweep,
+      and (bundled here) the full-session `emu.cfg` hash from the item below* — from
+      the spec's hardware verification plan plus Task 4/5/7's device items:
       - pairing completes with no IP ever typed in any quadrant (UDP 55441 broadcast
         + TCP 55440 handshake, not the old ping sweep).
       - only hosts broadcasting the *identical* game name appear in the client's
@@ -76,26 +68,11 @@ restores prior WiFi, stops a stray rsyncd, and removes the session file, bounded
         out of `netplay-data/`); host's `netplay-backup/` holds its pre-session copy.
       - after the session, `netstat` shows no listener on 55440/18731 on either
         device, and `pidof hostapd`/`pidof rsync` are clean.
-- [ ] **Migration regression** — on a card that still has `[network] GGPO = yes` (or
-      `input device2 = 0`) on disk from the old overlay-toggle flow, a plain
-      `A`-launch must fire the guard and go straight to a single-player game — no
-      90 s peer wait — and the on-disk values must now read `GGPO = no` /
-      `device2 = 10`.
 - [ ] **`emu.cfg` untouched by a netplay run** — hash/diff it before and after a full
       hosted and a full joined session on both devices: no key changes at all (the
-      migration guard's one-time rewrite aside), confirming the five netplay values
-      really are virtual-only.
-- [ ] **Cancel → game list** — cancelling the wizard at any step (before and after
-      network setup has started) returns cleanly to the game list; flycast is never
-      started on a non-zero wizard exit.
-- [ ] **Kill-and-heal** — kill the pak mid-session via the OSD/power path (bypassing
-      `launch.sh`'s own `--cleanup` call) instead of quitting normally, then start a
-      netplay attempt again: the startup self-heal must tear down the orphaned
-      hotspot/rsyncd and restore WiFi before the wizard's first menu, within the
-      19 s teardown budget (`WIZ_TEARDOWN_BUDGET_MS`).
-- [ ] **`sh -n` on-device** — re-check both DC.pak `launch.sh` files with the
-      device's own busybox ash (`adb shell sh -n <path>`); already clean under macOS
-      `sh -n`, but that is not proof against busybox's parser.
+      migration guard's one-time rewrite aside), confirming the six netplay values
+      really are virtual-only — including `DCNet`, which the netplay block forces to `no`
+      virtually and must therefore leave at its overlay value on disk.
 
 ### Gotchas
 
@@ -107,7 +84,11 @@ restores prior WiFi, stops a stray rsyncd, and removes the session file, bounded
   lease; `server =` semantics (empty → loopback deadlock, flycast's "Starting
   Network" modal has no timeout, Cancel is the only exit) are still exactly what a
   broken pairing looks like at the flycast layer, even though the wizard should now
-  make that unreachable in normal use.
+  make that unreachable in normal use. **DCNet is likewise forced off** (virtually,
+  `network:DCNet=no` last in `NETPLAY_ARGS`): it relays the emulated modem to an
+  external cloud service, an input the GGPO lockstep never synchronizes, so leaving a
+  per-game or global `DCNet = yes` in force on a session is a desync. It is on by
+  default now, so this is the common case, not a corner one.
 - **`PerGameVmu` must stay off.** With it on, flycast writes the per-game VMU file as
   `<gameId>_vmu_save_A1.bin`, which does not match the wizard's `--fetch-files` glob
   (`vmu_save_*.bin`) any more than it matched the old tar glob — the sync silently
@@ -312,24 +293,14 @@ sun50iw10, 2026-07-29 (device arrived, no SD card, redux not installed):
       Settings → Input Tester and press everything. Expected: 9/10 = stick clicks (L3/R3),
       11/12 = FN1/FN2 (shown as L4/R4), 13/14 = volume, 15 = HOME, 8 = MENU.
       Wrong indices look like dead or swapped buttons, **not** a crash.
-- [ ] **Analog sticks** — both nubs move the on-screen indicators; `L3+R3` enters calibration.
-- [x] **Hall-stick calibration** — RESOLVED 2026-07-29 on-device (stock fw): no
-      `/dev/ttyAS*` nodes exist at all, so NX's calibration (`settings_input.c:68-71`,
-      entered via `L3+R3` in the Input Tester) is a no-op on this model. Stock DOES
-      calibrate here, via a different transport with the same downstream contract:
-      the Brick Pro's sticks are read by `trimui_inputd` over I2C (`/dev/i2c-3`), and
-      stock MainUI's flow is touch `/tmp/joypad_testmode` (raw/uncalibrated ADC mode)
-      → sample → write the SAME `/mnt/UDISK/joypad.config` /
-      `joypad_right.config` files NX already writes → touch
-      `/tmp/trimui_inputd/cal_update` to make inputd reload ("calibrate update"
-      string). DECIDED 2026-07-29: implement a native brickpro calibration on this
-      mechanism. Same-day probe session reverse-engineered and hardware-verified the
-      full acquisition protocol (raw ADC does NOT pass through the event device —
-      the flag QUIESCES inputd; the calibrator reads the two stick ADC chips
-      directly: `/dev/i2c-3`, 7-bit 0x28/0x29, reg 0xB0, 4 bytes = X,Y u16 LE,
-      12-bit) — full protocol + design in `DEV_TODO.md` ("Trimui Brick Pro: joystick
-      calibration"). Until it lands, `L3+R3` on brickpro is known-inert. Note the
-      factory unit shipped with `joypad.config` present but NO `joypad_right.config`.
+- [ ] **Analog sticks** — both nubs move the on-screen indicators. Note: `L3+R3`
+      calibration is known-inert on this model until the I2C implementation lands
+      (protocol + design in `DEV_TODO.md`, "Trimui Brick Pro: joystick calibration").
+- [ ] **DC pre-launch options smoke (60 s)** — open "Emulator Options" once on a DC
+      game: proves seeding into `config/tg5040-brickpro` from `default-brickpro.cfg`.
+      Everything else on that feature is transitively covered — Brick Pro runs the same
+      tg5040 binaries at the same 1024×768/3× geometry verified on the Brick, and has no
+      fan daemon (the tg5050 picker-hang class does not apply).
 - [ ] **LEDs, all five zones** — Settings → LED Control shows F1 key / F2 key / Top bar /
       Joysticks / L/R triggers. Verify each zone lights the part it names (in particular that
       `lr` is the *joysticks* here and `rear` is the *triggers* — the opposite of the Brick).

--- a/DEV_CHECKLIST.md
+++ b/DEV_CHECKLIST.md
@@ -11,6 +11,439 @@ Move an entry from there to here once it compiles and needs hardware time.
 
 ---
 
+## DC netplay (GGPO + DCNet) overlay wiring (built 2026-07-28)
+
+**Status:** the first live pair test (2026-07-28, Brick ↔ Smart Pro S, MvC2) **SUCCEEDED** —
+both devices connected over GGPO and mirrored in lockstep, with no manual file copy and no
+IP ever typed. It exposed two defects, and **v2 fixes both**
+(`docs/superpowers/plans/2026-07-28-netplay-symmetric-discovery.md`): (1) MvC2's VS mode was
+unusable because Dreamcast port B was empty (`device2 = MDT_None`) — GGPO always drives port B
+as player 2, the remote player on the host but the LOCAL player on the client, which is exactly
+why the second device's Start did nothing, so BOTH machines need a pad there; launch.sh now sets
+`[input] device2 = 0` while GGPO is on and restores `10` when off; (2) discovery was asymmetric
+and timing-fragile — the host learned the
+client's IP passively from its own server access log inside a pre-launch window, so a client
+that was late, absent, or launched first left the host hung forever on "Starting Network"
+(no timeout, Cancel only) — both devices now serve a role-tagged `netplay-info` on TCP 19714
+and both scan the LAN for the opposite role, so launch order and timing are irrelevant.
+Underneath, unchanged from v1: "host brings the memory card" (TCP 19714 HTTP rendezvous, busybox
+httpd on tg5040 / python3 http.server on tg5050), isolated client `netplay-data/`, host
+`netplay-backup/`; design in `docs/superpowers/specs/2026-07-28-netplay-state-sync-design.md`.
+The v2 block is byte-identical in both DC.pak `launch.sh` files and bench-tested on the Brick
+via adb (cfg/probe/wget/tar mechanics all PASS, tar guard hardware-verified). v2's two-device
+symmetric discovery got its first real pair test on 2026-07-29 and **failed**: the client found
+the host, the host never found the client, and both then stalled at flycast's Starting Network
+modal. Two independent bugs were root-caused and fixed the same day — an ARP-sweep probe storm
+and a shared temp file in `nx_fetch` — see the Busy-LAN discovery entry below for the measured
+evidence. Post-fix, `nx_find_peer` finds a peer in 8 s on 3/3 runs against a fake peer on the
+same busy `/24`, but **the two-device pair test has not been re-run**; treat every v2 discovery
+path below as single-device evidence until it has.
+Discovery feedback landed on top of v2 (2026-07-28): a `show2.elf` daemon status screen fed
+`TEXT:`/`PROGRESS:` over `/tmp/show2.fifo`, plus two speed fixes (the stored `server =` is only
+probed when it is in the current /24, and neighbour probes now run concurrently).
+Bench-measured on the Brick (tg5040) 2026-07-29 — **function level only**: `nx_ui_start`
+returns rc=0 with a live PID, and the daemon is FIFO-ready and painting in **<=1 s** (three
+cold runs; 1 s poll granularity, so the true figure is at or under 1 s — this replaces the
+earlier ~3-4 s ESTIMATE, which was wrong by 3-4x); `--image=/dev/null` is accepted at runtime
+(`IMG_Load` logs "not a regular file or pipe" and rendering continues); `nx_ui` rc=0 with and
+without a progress argument; `nx_ui_stop` removes the FIFO and the daemon is gone in 1 s; with
+`show2.elf` off PATH all three are rc=0 no-ops in 0 s. That bench also caught a REAL SHIPPED
+BUG: plain `killall` (SIGTERM) does NOT kill show2 — measured alive 6 s later — so the
+code now uses `killall -9` (see Gotchas). Confirmed VISUALLY since (user, Brick 2026-07-29, with
+the rebuilt show2 driven by hand over adb — not from launch.sh): text renders, the second
+`--hint` line renders and persists across `TEXT:` updates, and the marquee animates, freezes on
+a numeric `PROGRESS:` and RE-ARMS on a later `PROGRESS:-1` (the re-arm two fix rounds were built
+on is now observed, not inferred). The deployed tg5050 binary was then exercised too (Smart Pro
+S, 2026-07-29 — that platform had never run show2 at all before): it starts with `--hint`,
+creates its FIFO in ~1 s, accepts `TEXT:` and `PROGRESS:` updates and stays alive. **What is
+still unverified: the feature has never run in a real game launch on either device.**
+"Hardware-verified" here means the shell functions behave and show2 draws what it is told; it
+does NOT mean the status screen has been seen driven by a real netplay launch.
+**B skips netplay** (built 2026-07-29): during discovery, pressing B stops the search and
+launches the game single-player for THAT RUN ONLY — launch.sh starts flycast with `-config
+network:GGPO=no`, which flycast keeps as a *virtual* value and never writes back, so `emu.cfg`
+still holds `GGPO = yes` afterwards and the next launch attempts netplay again. B is live from
+the moment the status screen starts until flycast is started, and is honoured at phase
+boundaries, in the discovery loops and inside `nx_fetch`'s watchdog. Bench-verified on the Brick
+2026-07-29, 12/12 checks against the functions extracted verbatim from launch.sh: arm/disarm
+lifecycle, stale-flag clearing, the flag honoured, and `nx_fetch` aborting 2 s into a 30 s
+timeout. The button number is settled on BOTH units: `00`, five consecutive presses each,
+raw `.. .. .. .. 01 00 01 00` on the Brick and identical on the Smart Pro S (2026-07-29), so the
+shared `NX_CANCEL_BTN=00` is right for both and the byte-identical block needs no per-device
+handling. **Still NOT verified, all three needing a real session: (1) an actual B press during a
+real game launch — that it cancels, lands in single-player and leaves `[network] GGPO = yes`
+afterwards; input cannot be injected over adb, so this has never run end to end; (2) any
+two-device pair test with the new block on both units; (3) the cancelled-client-plays-on-its-own
+-saves path, which is code-verified and reasoned but never exercised in a real session.**
+Flycast itself was not rebuilt — v2.6 already ships GGPO and DCNet compiled in — but `show2.elf`
+WAS rebuilt on both platforms for the hint line (new optional `--hint`) and is now **deployed to
+both devices** (2026-07-29): Brick md5 2678718c -> 4be3ac43, Smart Pro S fe7d510b -> c943d4b7,
+each md5-verified against the local build, syntax-checked with the device's own shell, and
+`show2.elf` resolves bare via PATH on both. Rollback needs no computer: the pre-change binary is
+kept on-device as `show2.elf.orig` beside it (a second copy lives in the SDD snapshots) — worth
+keeping, since show2.elf is ALSO the first-boot install splash. Remaining deploy for this
+feature = push `overlay_settings.json` to `$SDCARD/Emus/shared/flycast/` + both DC.pak
+`launch.sh` files to their pak dirs on both cards.
+
+### On-device verification
+
+- [ ] **Overlay round-trip** — "Netplay" section renders with all 4 items; after toggling
+      and quitting, `emu.cfg` gains the `[network]` keys (`GGPO`/`ActAsServer`/`DCNet` as
+      yes/no, `GGPODelay` as int) and existing `[config]`/`[achievements]` values are not
+      clobbered (flycast rewrites the whole cfgdb on quit).
+- [ ] **GGPO zero-config LAN match (v2 re-run)** — Brick ↔ Smart Pro S, Marvel vs.
+      Capcom 2 (byte-identical chd + `dc_boot.bin` on both cards; wifi on). Overlay:
+      GGPO on on both, Host on exactly one. Launch order is free (see below); a wait
+      of up to 90 s per side is expected while discovery runs, covered by the status
+      screen (measured FIFO-ready and painting in <=1 s on tg5040). A pairing fast
+      enough to beat even that shows the screen only briefly or not at all, which is
+      equally correct. Match must
+      connect with NO manual file copy and NO IP ever typed. Verify `[network]
+      server =` got auto-written on BOTH devices' emu.cfg. (v1 already passed this
+      with host-first ordering — the point of the re-run is that v2 still does.)
+- [ ] **P2 controller** — with netplay on, MvC2's VS mode is selectable and the second
+      device's Start/inputs register as Player 2; confirm `[input] device2 = 0` appears
+      in BOTH devices' emu.cfg. Then toggle netplay off, relaunch, and confirm it went
+      back to `10` (single-player sees a one-pad Dreamcast).
+- [ ] **Launch order is free** — client-role device launched FIRST, host second: they
+      must still pair (this is what v1 could not do).
+- [ ] **Repeat-session fast path** — second run with an unchanged peer IP should pair
+      almost immediately (stored `server =` probe hits before any ping sweep). Only
+      applies on a /24 lease with the stored address inside it; off-subnet or on any
+      non-/24 lease the fast path is skipped by design and the sweep runs.
+- [ ] **Stale peer IP** — change one device's DHCP lease (or edit `server =` to a dead
+      address), relaunch: the sweep must still find the peer and rewrite `server =`.
+- [ ] **Two hosts / two clients** — set both devices to the same role: they must NOT
+      pair (role line mismatch), and both must fail open rather than hang in launch.sh.
+- [ ] **tg5050 serve branch** — RESOLVED 2026-07-28 on-device: Smart Pro S runs
+      busybox 1.35.0 with NO `httpd` and NO `nc` applet; `wget`/`tar`/`ping -W`/
+      `ip`/`wlan0` all verified present, and the fallback serve branch
+      (`python3 -u -m http.server`, python3.10 on firmware) was smoke-tested there
+      (serves, wget round-trip). Remaining on-device item: one session ON the Smart
+      Pro S in each role to exercise the python branch end-to-end in a real launch
+      (both roles now run a server, so the branch is on the client path too).
+- [ ] **Role swap** — after a session, swap Host/join roles and reconnect: the new
+      host's own solo-unlocked content must be what both players see (its REAL card
+      is now the source), not the previous session's borrowed copy.
+- [ ] **Client real-save integrity** — md5 the client's `data/flycast/vmu_save_*`
+      + `dc_nvmem.bin` before and after a full netplay session: byte-identical
+      (client plays entirely in `netplay-data/`).
+- [ ] **Tar guard** — the client extracts the synced tar only when all FIVE conditions
+      hold: non-empty; `tar tf` lists at least one entry (a non-tar payload lists
+      nothing and would pass the negated tests vacuously); every entry is a bare
+      expected NAME (`vmu_save_[A-D][12].bin` / `dc_nvmem.bin`, no slashes, no `..`,
+      no absolute paths); every `tar tvf` mode column is `-`; and no entry is a link
+      (` -> ` — NOT redundant with the mode column, since busybox prints a HARDLINK
+      with a leading `-`; flycast would otherwise write VMU data through a link as
+      root). Bench-verified on the Brick 2026-07-28 (ACCEPT good tar; REJECT
+      path-traversal, symlink, hardlink, non-tar junk, empty) — the on-device item is
+      confirming a hand-crafted bad tar is refused inside a REAL launch and it still
+      falls open.
+- [ ] **Host backup** — after any hosted session: `netplay-backup/` contains
+      pre-session copies of `vmu_save_*.bin` + `dc_nvmem.bin`.
+- [ ] **Wrong-game refusal** — device A on game A, device B on game B: they must NOT
+      pair (netplay-info ROM line mismatch), and each falls open into a normal
+      (failing) GGPO launch after its 90 s scan.
+- [ ] **Fail-open sanity** — one device launched with GGPO on and no peer anywhere:
+      after its 90 s scan it must still reach flycast, never a stall in launch.sh
+      (the status screen should be expected to vanish on whichever message survived —
+      on the client that is "looking for the host..."; on the host it is EITHER
+      "preparing saves..." OR "looking for player 2 on ..." — the host never emits the
+      client's string; the "no ... found - starting anyway" update is queued and then
+      killed with the daemon, so do NOT judge on seeing it). Expect flycast to sit on
+      "Starting Network" (it has no
+      timeout — Cancel is the only exit); that is GGPO's behavior, not a launch.sh
+      hang, and it is what the user sees whenever `server =` is empty or wrong.
+- [ ] **Rollback headroom on Brick** — watch for re-simulation hitches mid-match (GGPO
+      forces SH4 to stock 200 MHz; A53s have limited headroom). If hitchy, Input Delay 2–3.
+- [ ] **Disconnect behavior** — opening the overlay or save/load state mid-match pauses
+      emulation → peer drops after 3 s of silence. Confirm this fails as a clean error/
+      return to gameplay, not a hang.
+- [ ] **DCNet smoke test** — `DCNet = yes` with an online-capable game if one is on hand
+      (ChuChu Rocket, Quake III, PSO); expect the "Connected to DCNet with modem" toast.
+      MvC2 is expected to show nothing (no native online mode). Needs internet, not LAN.
+- [ ] **UPnP off** — launch.sh now writes `[network] EnableUPnP = no` on every GGPO
+      launch, so no hand edit is needed on `.initialized` devices any more. Verify the
+      key is present in BOTH devices' live emu.cfg after a netplay launch, and that no
+      router port-mapping for UDP 19713 appears (flycast defaults UPnP on and leases the
+      mapping for 24 h).
+- [ ] **UPnP on an upgraded install** — start from the real case for every existing
+      device: `EnableUPnP` absent from emu.cfg entirely. Launch with GGPO on and confirm
+      no UDP 19713 mapping appears on the router, in BOTH roles (`ggpo.cpp:801-804`
+      punches the mapping before the `ActAsServer` branch, so host and client both would).
+- [x] **Busy-LAN discovery** — this is where the first real pair test failed, and it took
+      two independent bugs to explain it. Both are fixed and re-verified on the Brick
+      (2026-07-29); the item stays on the list only because the *pair* re-test is still owed.
+      (1) A `/24` ping sweep leaves an ARP entry for every address probed, and this router
+      answers ARP for unused addresses: `ip neigh | grep -c lladdr` went 22 -> **259** across
+      a sweep, decaying back to 22 about 20 s later. One background probe per entry meant
+      ~250 concurrent wgets on a 4-core handheld inside a 4 s collect window. `nx_find_peer`
+      now dedups by MAC before probing (measured 222 -> 16 candidates, peer included).
+      Note busybox `sort -u -k1,1` compares WHOLE LINES and does not dedup by key — awk does it.
+      (2) The decisive one: `nx_fetch` named its download `/tmp/nx_netplay_fetch.$$`, and in
+      POSIX sh `$$` keeps the PARENT shell's pid inside a subshell — verified, parent and both
+      subshell forms all printed 27146 — so every concurrent probe shared one file. One probe's
+      trailing `rm -f` deletes another's payload (16 concurrent probes against a LAN with
+      exactly one real peer returned **zero** hits), and a dead host's `cat` can read a live
+      host's payload and win `ls | sort | head -1` (observed: 192.168.1.14, which refuses
+      connections on 19714, beat the real peer). `nx_fetch` now uses `mktemp` with a
+      URL-derived fallback. The two bugs mask each other: dedup alone cannot fix discovery,
+      and the temp-file fix alone would drown under ~250 probes.
+      The storm is **device-dependent**, and that is what explains why the client found the
+      host but never the reverse. Same LAN, same moment, identical sweep: the Brick goes
+      22 -> **259** neighbours, the Smart Pro S goes 3 -> **13**. So the Smart Pro S spawned
+      few enough probes that the temp-file race still let a hit through occasionally, while
+      the Brick spawned ~250 and never got one. (Mechanism behind 259-vs-13 not established —
+      band/AP or neighbour-table GC — only that it is real and repeatable.) Practical
+      consequence: **bench discovery on the Brick**; the Smart Pro S is not sensitive enough
+      to expose this class of bug.
+      Verification rig, reusable: run a peer on any same-subnet host with
+      `printf 'GAME\nclient\n' > netplay-info && python3 -m http.server 19714`, extract the
+      discovery functions from the deployed launch.sh with awk (one function at a time —
+      overlapping `sed` ranges silently duplicate one-liner bodies like `nx_cancelled`),
+      then call `nx_find_peer client`. Post-fix: 3/3 runs found the peer in 8 s each, on the
+      same LAN that shows 259 phantom neighbours. Misses are still never cached.
+- [ ] **Discovery: known limits accepted, NOT bugs to re-derive** — a review of the 2026-07-29
+      discovery fix raised these; each was checked and consciously left alone. Read this before
+      "fixing" any of them.
+      (a) *MAC dedup can drop the real peer.* `awk '!seen[$1]++'` keeps one IP per MAC in kernel
+      hash order. If the AP answers the sweep's ARP for the peer's own address with the AP's MAC
+      and that reply wins the cache, the peer joins the AP's group and is only probed if it
+      happens to be first in hash order — and it would fail identically every pass for the full
+      90 s. Empirically the peer survived on both devices across 6 runs (last-reply-wins appears
+      to favour the real station). No cheap complete fix exists: probing all ~222 in batches
+      would eat ~64 s of the 90 s budget. Dedup trades completeness for load; at 222 candidates
+      that is the right trade. If this ever does bite, the cheapest mitigation is appending the
+      stored `server =` to the candidate list unconditionally.
+      (b) *Candidates are not filtered to the local /24.* Verified: `10.0.0.5` on a second
+      interface survives dedup and gets probed. Harmless waste on a normal LAN; left alone
+      because filtering must be conditional on `NXP_NET` being non-empty or it would break
+      discovery entirely on a non-/24 lease.
+      (c) *`NETPLAY_DEADLINE=90` is a loop-ENTRY deadline.* Parallelising the probes dropped the
+      per-candidate deadline check, so a pass starting at T+89 still runs its full ~8 s and the
+      `$( )` then waits on stragglers. Real bound is ~90 + 8 + one probe.
+      (d) *`$NXP_HITS` safety rests on an unstated timing margin.* A probe lives <=3 s; the gap
+      from spawn to the next pass's `mkdir -p` is `sleep 4` + `sleep 3` = 7 s. **Invariant: the
+      collect `sleep 4` must exceed `nx_fetch`'s watchdog argument.** Shorten one or raise the
+      other and hits start crossing passes (worst case: one lost pass, ~8 s).
+      (e) *The mktemp fallback is not collision-free in one dormant case* — the same IP on two
+      interfaces with different MACs survives dedup twice and both fallback names are identical.
+      Dormant because `mktemp` is present on both devices, and both probes target the same host
+      so a stolen payload is the right payload.
+      (f) *`ls | sort | head -1` is lexicographic, not numeric* (`.100` < `.20` < `.9`). Fine for
+      the one-real-peer case; with two eligible peers the "same LAN picks the same peer"
+      property is weaker than it sounds, since which IP wins each MAC slot is kernel hash order.
+- [ ] **Two-device pair re-test** — the actual outstanding item: host on one device, client
+      on the other, both on the busy `/24`. Host must reach "found player 2" rather than
+      sitting out the 90 s deadline, and both must clear flycast's Starting Network modal.
+- [ ] **python3 serve branch under the real launch env** — the tg5050 smoke test above
+      ran from a bare adb shell; launch.sh prepends repo-built libs to `LD_LIBRARY_PATH`
+      (tg5050 launch.sh:47). Confirm `python3 -u -m http.server` still starts and serves
+      a fetchable `netplay-info` with that exact environment applied.
+- [ ] **Overlay token after an unclean exit** — toggle GGPO on, then power-cut instead of
+      quitting cleanly; confirm `emu.cfg` still holds `GGPO = yes` (not `True`). A `True`
+      is the one state that would make launch.sh skip the netplay block entirely while
+      flycast itself still enables GGPO — i.e. netplay with no discovery and no sync.
+- [ ] **Filename-mismatch pairing** — the same CHD under two different filenames on the
+      two cards: they must NOT pair (`netplay-info` line 1 is the extension-stripped ROM
+      filename, not a content hash). Confirm the symptom stays thin: the status screen
+      sits for the full 90 s on whichever message survived show2's init window — on
+      the client "looking for the host...", its only pre-wait message; on the host
+      EITHER "preparing saves..." OR "looking for player 2 on ..." — then simply
+      disappears, since the "starting anyway" update is queued and killed before it
+      can be read. Then
+      flycast's untimed "Starting Network" — nothing names the mismatch.
+- [ ] **Local two-pad regression** — with GGPO off, set `[input] device2 = 0` through
+      flycast's OWN Controls UI for local two-pad play, relaunch with GGPO still off, and
+      record that the restore branch reverts it to `10` (it cannot distinguish that value
+      from one this block wrote).
+- [ ] **Server cleanup on a pak kill** — quit through the OSD/power path rather than
+      flycast's own exit, then `netstat -tln | grep 19714`: the cleanup block only runs
+      after `wait $EMU_PID`, so a kill that bypasses it may leave the serve dir listening.
+- [ ] **GGPODelay asymmetry** — set a different Input Delay on each side and confirm it is
+      NOT a desync (`inputSize` depends on `GGPOAnalogAxes`, not on delay), so the "must
+      match" warning stays correctly scoped to `GGPOAnalogAxes` and `device2`.
+- [ ] **No stray listener** — after a normal quit, a crash, and a power-off mid-session:
+      port 19714 must not be listening (`netstat -tln`); the serve dir is LAN-readable
+      for as long as a server lives.
+- [ ] **Dead/duplicate server** — launch either device with 19714 already bound (or
+      double launch): launch.sh must fall open and reach flycast rather than stall.
+      Burning the full 90 s deadline is NOT a failure — a device with no reachable
+      peer always does; the assertion is that the launch proceeds. Note observed
+      behavior. Both roles run a server now, so this applies to host and client alike.
+- [ ] **Upgraded-install cfg creation** — on a real `.initialized` device cfg (no
+      seeded `[network]`, and typically no `[input]` section at all): overlay toggle
+      creates `[network]`, discovery creates `server =` from scratch, and the netplay
+      block creates `[input] device2` from scratch (bench proved the mechanics on a
+      live-shaped cfg, not the live file).
+- [ ] **tg5050 tar guard on hardware** — re-run the five-condition guard cases under
+      Smart Pro S busybox 1.35 tar (the hardlink/mode-column rendering is verified on
+      the Brick's busybox 1.27.2 only).
+- [ ] **Speaker pop on netplay launches** — unmute timer fires at T+5 s but flycast
+      can start up to 90 s later; listen for the pop the mute normally suppresses.
+- [ ] **DCNet + GGPO together** — README claims independence; confirm on-device or
+      document mutual exclusion (DCNet's non-deterministic traffic would desync
+      rollback).
+- [ ] **Non-/24 LAN** — a device on a /16 or /23 lease: neighbor-only scan, clean
+      fail-open, and no self-pairing with its own server (each device now serves one).
+      Now true in a stronger sense: the address is parsed with a `/24`-only `sed`, so
+      off a /24 the subnet comes back empty and the stored `server =` is skipped
+      UNCONDITIONALLY, not just when the octets differ. Consequence to check: a
+      hand-set `server =` is never probed by the FAST PATH there — the `ip neigh` loop
+      still runs, so that host is reachable only if it already sits in the ARP cache,
+      and nothing sweeps to populate that table off a /24. So the client may pull no
+      save tar even though flycast still connects on that address (launch.sh leaves
+      the value alone when discovery finds nothing) — GGPO connects, sync does not.
+- [ ] **Status screen appears** — SETUP MATTERS: run this with the peer absent, or
+      with `[network] server =` cleared on this device first, so the wait is long
+      enough (90 s / >=7 s) to exercise the `TEXT:` update path properly. On the fast
+      path discovery can outrun the screen and either a brief flash or nothing at all
+      is correct — that is the item below, not this one. With this setup, PASS = all
+      three of: (1) a netplay
+      status screen appears; (2) the message on it is ONE OF the literal strings
+      below; (3) the launch proceeds to flycast. ONE EXCEPTION, and it is a FAIL: if
+      `Starting...` is the only thing ever shown for the whole wait, no
+      `TEXT:` update reached the FIFO — that string is show2's own `--text=` argument,
+      painted from the first frame whether or not the update path works at all (a
+      failed `mkfifo` only `perror`s and keeps rendering, `show2.cpp:238-241`; an
+      `nx_ui` subshell that exhausts its 10 s poll budget exits silently,
+      `launch.sh:229`). This is the only item that exercises the `TEXT:`/`PROGRESS:`
+      path *from launch.sh*, on either device (the deployed tg5050 show2 has accepted
+      `TEXT:`/`PROGRESS:` by hand, but nothing has driven it through a real launch
+      there). It cannot false-fail a correct run:
+      with the setup above the wait is >=7 s (cleared `server =`) or 90 s (peer
+      absent), against a 1 s poll and a 10 s budget. Otherwise do NOT require a
+      particular message, or any particular sequence — the design guarantees neither.
+      Expected survivors,
+      by role, quoted exactly as launch.sh emits them (the `Netplay: ` prefix these
+      strings once carried was dropped 2026-07-29 after it read as clipped on hardware —
+      a screen still showing it is running an old launch.sh): CLIENT — `Looking for
+      the host...` (it queues only one pre-wait message). HOST — EITHER `Preparing
+      saves...` OR `Looking for player 2 on <subnet>.x...`, which
+      off a /24 reads `Looking for player 2 on the network...`. Sent but
+      rarely seen: `Starting...` (the daemon's own `--text=`), `Player 2 found at
+      <ip>`, `No player 2 found - starting anyway`,
+      `No host found - starting anyway`. The one terminal message that IS
+      readable is the client's `Host found at <ip> - copying saves...`,
+      which dwells ~1-2 s (the tar fetch of a ~384 KB card over LAN, plus a few `tar`
+      spawns; the 30 s in `nx_fetch` is only the watchdog ceiling for a stalled host).
+      Why the chain is not assertable: (a) each `nx_ui` call polls for the FIFO from
+      its OWN background subshell on an independent `sleep 1` cadence, so among the
+      messages queued before the FIFO exists ANY of them may be the survivor — on the
+      host it can be "preparing saves..." or "looking for player 2 on ...", either
+      way; (b) terminal messages are only queued, and the very next thing launch.sh
+      does is `nx_ui_stop`, whose `killall -9` destroys the daemon within
+      milliseconds — at 60 fps that is ~17 ms (derived, not measured) to paint a frame
+      that is then torn down.
+- [ ] **Fast path — brief screen or none, BOTH correct** — the counterpart to the item
+      above, worth recording deliberately because it is the state a tester will be in
+      by default (every preceding pair test auto-writes `server =` on both devices).
+      Relaunch with a valid stored `server =` and the peer up: the stored probe returns
+      in ~1 s (`nx_fetch` checks `kill -0` BEFORE its first `sleep 1`), so the whole
+      block finishes in roughly 1.5-2.5 s on the host and 2.5-3 s on the client. With
+      init measured at <=1 s the screen will PROBABLY paint briefly and then vanish —
+      but a run where it never appears at all is equally correct. PASS = the launch is
+      fast and reaches flycast; do NOT fail it either way. (This was written when init
+      was estimated at ~3-4 s and predicted a guaranteed black screen; the measurement
+      inverted that prediction, hence the either-outcome wording.) The insight the item
+      exists to record is unchanged: the faster discovery gets, the less the status
+      screen has to show, because there is less wait left to cover. Use the peerless /
+      cleared-`server =` setup of the item above — not this one — to actually exercise
+      the `TEXT:` update path.
+- [ ] **Status screen never outlives the launch** — after flycast starts, confirm no
+      `show2.elf` process remains. Use `pgrep -x show2.elf`. NOT `pgrep -f show2` and
+      NOT a bare `ps | grep show2`: both match the checking shell's own command line
+      and report a phantom hit (this actually fooled a bench session). Check on both
+      roles. Cleanup depends on `killall -9` — see the Gotchas entry; if a plain
+      SIGTERM ever gets restored here, this item is what catches it.
+- [ ] **Degrades silently** — rename `show2.elf`, relaunch: netplay must still work,
+      just without the status screen, and must not stall.
+- [ ] **Relocation is fast** — join a different network so the stored `server =`
+      is on the old subnet; confirm the stale address is skipped (no ~3 s dead
+      probe) and discovery still finds the peer.
+- [ ] **Busy-LAN scan time** — on the 60-AP location, time ONE discovery pass, not a
+      full failed scan: a failed scan is deadline-bound at 90 s under serial and
+      concurrent probing alike, so it cannot tell the two apart. A pass is a fixed
+      ~7 s (3 s sweep settle + 4 s collect) plus the slowest straggler probe, each
+      bounded by the 3 s fetch watchdog — and crucially that figure must NOT grow
+      with the neighbour count. Count the neighbours (`ip neigh | wc -l`) so the
+      "does not scale" claim has a number attached.
+- [ ] **B skips netplay** — wait until the netplay screen is actually up and the
+      "B = skip netplay" hint is visible, THEN press B (pressing during show2's
+      own startup still cancels, but the confirmation cannot be drawn yet because
+      its FIFO does not exist). The screen should change to
+      `Skipped - starting game...` and the game should start
+      single-player within a couple of seconds. Afterwards confirm
+      `[network] GGPO` is STILL `yes` in emu.cfg — the skip is per-run only.
+- [ ] **Cancelled client uses its OWN saves** — cancel on the client role, then
+      check in-game that the VMU content is the client's own, not the host's
+      borrowed copy (netplay isolation is skipped when cancelled).
+- [ ] **B works outside the search too** — press B while the host is preparing
+      saves, and (separately) while the client is copying saves: both must skip.
+- [ ] **Only B cancels** — press A, X, Y, START and move the stick during the
+      search: none may skip netplay.
+- [x] **B is button `00` on BOTH units** — RESOLVED 2026-07-29 on-device: five
+      consecutive presses on the Smart Pro S read `.. .. .. .. 01 00 01 00`,
+      identical to the Brick, so the shared `NX_CANCEL_BTN=00` is correct for both
+      and the byte-identical block needs no per-device handling. Keep the method
+      note if this is ever re-measured: read js0 the way launch.sh does — open once,
+      then `dd bs=8 count=1 <&3 | hexdump`. A buffered `dd | hexdump | while read`
+      pipeline gives WRONG numbers, and that is exactly how the discarded "B = 02"
+      reading was produced — do not "correct" `00` back to it.
+- [ ] **Hint is legible** — both lines visible and unclipped, hint stays put while
+      the status line changes. (Both cards were updated to the `--hint`-capable
+      show2.elf on 2026-07-29, so a missing hint line means something other than an
+      old binary — check the deploy first anyway with `md5sum`: 4be3ac43 on the
+      Brick, c943d4b7 on the Smart Pro S.)
+- [ ] **Leftover input reader clears itself** — on a NON-cancelled netplay launch
+      the reader's `dd`/`hexdump` children outlive `nx_cancel_disarm` by design.
+      Find them with `readlink /proc/*/fd/*` matching `/dev/input/js0` — NOT by
+      cmdline, since the path is a redirection and never appears in argv. Just
+      after the game starts they may still be listed; press any controller button
+      and re-check: they must be gone, because `dd` ran with `count=1`. Confirm
+      in-game input is unaffected while they linger.
+- [ ] **Install splash unaffected** — the deployed show2.elf is also the first-boot
+      splash; run `install/boot.sh`'s invocation (no `--hint`) and confirm it
+      renders as before. Bench-passed pre-deploy on the Brick with boot.sh's exact
+      argument list (starts, FIFO in 1 s, accepts `TEXT:`, log identical to the
+      baseline); this item is the same check against the binary now on the card, on
+      both devices. If it ever fails, `show2.elf.orig` sits beside it on-device.
+
+### Gotchas
+
+- `GGPO = yes` persists across quits — every subsequent launch of ANY DC game waits for a
+  netplay peer until it's toggled back off in the overlay. Turn it off after playing.
+  Pressing B to skip does NOT count as turning it off: it disables netplay for that one
+  run through a virtual `-config` value flycast never writes to `emu.cfg`, so the next
+  launch searches again — and `[input] device2` stays at `0` until a launch with GGPO
+  actually off puts it back to `10`.
+- The peer IP (`server =`) is auto-written by launch.sh discovery on both sides, and
+  is probed first on the next launch (fast path) — but ONLY when the device holds a
+  /24 lease AND the stored address is inside it. Off-subnet (after a relocation) or
+  on any non-/24 lease it is skipped entirely, which is what makes those launches
+  fast instead of costing a dead ~3 s probe. Manual emu.cfg edit is a fallback for
+  LANs where the /24 sweep + neighbor probe can't find the peer, with the same
+  caveat: on a non-/24 lease a hand-set value is never probed by the fast path (the
+  `ip neigh` loop still runs, but nothing sweeps to populate that table off a /24,
+  so it only helps if the peer is already in the ARP cache), and flycast may then
+  connect on that address while the client still pulls no save tar.
+- `GGPO = yes` persisting (previous gotcha) now also means the discovery/sync phase
+  (up to 90 s) runs on EVERY DC launch until it's toggled off — one more reason
+  to turn it off after playing. It also means `[input] device2` stays at `0`
+  (port B occupied) until a launch with GGPO off puts it back to `10`.
+- Netplay launches must be plain "A START", never switcher-resume (slot-9 load after
+  GGPO's boot-time start desyncs; the client's slot 9 lives in `netplay-data/` so
+  normal resume is never polluted, but the host's real slot 9 is).
+- **show2 must be killed with `killall -9`, never plain `killall`.** Measured on the
+  Brick 2026-07-29: SIGTERM leaves it alive (still running 6 s later); `-9` kills it
+  instantly. show2 installs a handler for SIGINT only (`show2.cpp:623`), and
+  `SDL_Init` traps SIGTERM into an `SDL_QUIT` event that show2's daemon loop never
+  pumps — so the signal is swallowed. `nx_ui_stop` uses `-9` for this reason, as does
+  `MinUI.pak/launch.sh:228`. Anything that "tidies" it back to a plain `killall`
+  leaves the status screen holding the display against flycast.
+
+---
+
 ## Upstream-port + fix round (built 2026-07-27)
 
 **Status:** ten DEV_TODO items implemented 2026-07-27, committed as `1ccc1030`. All
@@ -146,6 +579,34 @@ Confirmed by reading the stock rootfs out of
   `osd-brickpro/` overlay (built from `skeleton/SYSTEM/osd/device/brickpro/` at
   package time) exists
 
+Confirmed live over adb on the actual unit, stock firmware v1.1.1 / kernel 4.9.191
+sun50iw10, 2026-07-29 (device arrived, no SD card, redux not installed):
+
+- `strings /usr/trimui/bin/MainUI | grep ^Trimui` → exactly one line, `Trimui Brick Pro`
+- panel live at 1024×768@60 (disp sysfs + fbset); `overlay` in `/proc/filesystems`
+  (kernel 4.9 → the tg5040 tmpfs-staging OSD mount branch is the right one here too)
+- `/sys/class/led_anim/` has `effect_{f1,f2,m,lr,rear}` + `max_scale`,
+  `max_scale_f1f2`, `max_scale_lr`, `max_scale_rear` exactly as tabled — plus
+  standalone `effect_l` / `effect_r` (and matching rgb_hex/cycles/duration nodes),
+  so the two `lr` sides are individually addressable (23 RGB LEDs in
+  `/sys/class/leds/`); possible future refinement, not needed for bring-up
+- `trimui_inputd` and `keymon` running; `trimui_osdd` runs from
+  `/usr/trimui/osd/trimui_osdd` (the overlay mount point); turbo interface is the
+  same `/tmp/trimui_inputd/turbo_*` flag files (per its own `help` file)
+- PD14/PD18 analog-pad GPIO poke confirmed commented out in the LIVE
+  `runtrimui.sh` (not just the recovery image)
+- busybox v1.27.2 — same as the Brick (tar guard / applet findings carry over)
+- **`TRIMUI Player1` key bitmap decodes to exactly the expected SDL order**:
+  BTN range 304-318 (A,B,X,Y,TL,TR,SELECT,START,MODE,THUMBL,THUMBR → SDL 0-10),
+  then low keys KEY_F1(59), KEY_F2(60), VOLDOWN(114), VOLUP(115),
+  KEY_HOMEPAGE(172) → SDL 11-15. That is 8=MENU, 9/10=L3/R3, 11/12=FN1/FN2,
+  13/14=volume, 15=HOME — kernel-level evidence for the Input Tester item below
+  (still confirm in SDL once redux is installed). ABS=3003f → both sticks,
+  analog triggers, dpad hat all present on the one device. HOME is
+  KEY_HOMEPAGE(172) *emitted by the gamepad device*, so SDL sees it as joystick
+  button 15 and keymon's tg5050 keyboard-device Home path indeed does not apply.
+- `/dev/ttyAS*` — NONE exist (see resolved calibration item below)
+
 ### 1. On-device verification (Brick Pro)
 
 - [ ] **Boots and identifies correctly** — UI is 1024×768 at 3× scale with 7 main rows.
@@ -155,8 +616,23 @@ Confirmed by reading the stock rootfs out of
       11/12 = FN1/FN2 (shown as L4/R4), 13/14 = volume, 15 = HOME, 8 = MENU.
       Wrong indices look like dead or swapped buttons, **not** a crash.
 - [ ] **Analog sticks** — both nubs move the on-screen indicators; `L3+R3` enters calibration.
-- [ ] **Hall-stick calibration** — check whether `/dev/ttyAS5` / `/dev/ttyAS7`
-      (`settings_input.c:68-71`) exist on this model; calibration is a no-op if they don't.
+- [x] **Hall-stick calibration** — RESOLVED 2026-07-29 on-device (stock fw): no
+      `/dev/ttyAS*` nodes exist at all, so NX's calibration (`settings_input.c:68-71`,
+      entered via `L3+R3` in the Input Tester) is a no-op on this model. Stock DOES
+      calibrate here, via a different transport with the same downstream contract:
+      the Brick Pro's sticks are read by `trimui_inputd` over I2C (`/dev/i2c-3`), and
+      stock MainUI's flow is touch `/tmp/joypad_testmode` (raw/uncalibrated ADC mode)
+      → sample → write the SAME `/mnt/UDISK/joypad.config` /
+      `joypad_right.config` files NX already writes → touch
+      `/tmp/trimui_inputd/cal_update` to make inputd reload ("calibrate update"
+      string). DECIDED 2026-07-29: implement a native brickpro calibration on this
+      mechanism. Same-day probe session reverse-engineered and hardware-verified the
+      full acquisition protocol (raw ADC does NOT pass through the event device —
+      the flag QUIESCES inputd; the calibrator reads the two stick ADC chips
+      directly: `/dev/i2c-3`, 7-bit 0x28/0x29, reg 0xB0, 4 bytes = X,Y u16 LE,
+      12-bit) — full protocol + design in `DEV_TODO.md` ("Trimui Brick Pro: joystick
+      calibration"). Until it lands, `L3+R3` on brickpro is known-inert. Note the
+      factory unit shipped with `joypad.config` present but NO `joypad_right.config`.
 - [ ] **LEDs, all five zones** — Settings → LED Control shows F1 key / F2 key / Top bar /
       Joysticks / L/R triggers. Verify each zone lights the part it names (in particular that
       `lr` is the *joysticks* here and `rear` is the *triggers* — the opposite of the Brick).

--- a/DEV_CHECKLIST.md
+++ b/DEV_CHECKLIST.md
@@ -11,436 +11,133 @@ Move an entry from there to here once it compiles and needs hardware time.
 
 ---
 
-## DC netplay (GGPO + DCNet) overlay wiring (built 2026-07-28)
+## DC netplay pre-launch wizard (built 2026-07-29)
 
-**Status:** the first live pair test (2026-07-28, Brick ↔ Smart Pro S, MvC2) **SUCCEEDED** —
-both devices connected over GGPO and mirrored in lockstep, with no manual file copy and no
-IP ever typed. It exposed two defects, and **v2 fixes both**
-(`docs/superpowers/plans/2026-07-28-netplay-symmetric-discovery.md`): (1) MvC2's VS mode was
-unusable because Dreamcast port B was empty (`device2 = MDT_None`) — GGPO always drives port B
-as player 2, the remote player on the host but the LOCAL player on the client, which is exactly
-why the second device's Start did nothing, so BOTH machines need a pad there; launch.sh now sets
-`[input] device2 = 0` while GGPO is on and restores `10` when off; (2) discovery was asymmetric
-and timing-fragile — the host learned the
-client's IP passively from its own server access log inside a pre-launch window, so a client
-that was late, absent, or launched first left the host hung forever on "Starting Network"
-(no timeout, Cancel only) — both devices now serve a role-tagged `netplay-info` on TCP 19714
-and both scan the LAN for the opposite role, so launch order and timing are irrelevant.
-Underneath, unchanged from v1: "host brings the memory card" (TCP 19714 HTTP rendezvous, busybox
-httpd on tg5040 / python3 http.server on tg5050), isolated client `netplay-data/`, host
-`netplay-backup/`; design in `docs/superpowers/specs/2026-07-28-netplay-state-sync-design.md`.
-The v2 block is byte-identical in both DC.pak `launch.sh` files and bench-tested on the Brick
-via adb (cfg/probe/wget/tar mechanics all PASS, tar guard hardware-verified). v2's two-device
-symmetric discovery got its first real pair test on 2026-07-29 and **failed**: the client found
-the host, the host never found the client, and both then stalled at flycast's Starting Network
-modal. Two independent bugs were root-caused and fixed the same day — an ARP-sweep probe storm
-and a shared temp file in `nx_fetch` — see the Busy-LAN discovery entry below for the measured
-evidence. Post-fix, `nx_find_peer` finds a peer in 8 s on 3/3 runs against a fake peer on the
-same busy `/24`, but **the two-device pair test has not been re-run**; treat every v2 discovery
-path below as single-device evidence until it has.
-Discovery feedback landed on top of v2 (2026-07-28): a `show2.elf` daemon status screen fed
-`TEXT:`/`PROGRESS:` over `/tmp/show2.fifo`, plus two speed fixes (the stored `server =` is only
-probed when it is in the current /24, and neighbour probes now run concurrently).
-Bench-measured on the Brick (tg5040) 2026-07-29 — **function level only**: `nx_ui_start`
-returns rc=0 with a live PID, and the daemon is FIFO-ready and painting in **<=1 s** (three
-cold runs; 1 s poll granularity, so the true figure is at or under 1 s — this replaces the
-earlier ~3-4 s ESTIMATE, which was wrong by 3-4x); `--image=/dev/null` is accepted at runtime
-(`IMG_Load` logs "not a regular file or pipe" and rendering continues); `nx_ui` rc=0 with and
-without a progress argument; `nx_ui_stop` removes the FIFO and the daemon is gone in 1 s; with
-`show2.elf` off PATH all three are rc=0 no-ops in 0 s. That bench also caught a REAL SHIPPED
-BUG: plain `killall` (SIGTERM) does NOT kill show2 — measured alive 6 s later — so the
-code now uses `killall -9` (see Gotchas). Confirmed VISUALLY since (user, Brick 2026-07-29, with
-the rebuilt show2 driven by hand over adb — not from launch.sh): text renders, the second
-`--hint` line renders and persists across `TEXT:` updates, and the marquee animates, freezes on
-a numeric `PROGRESS:` and RE-ARMS on a later `PROGRESS:-1` (the re-arm two fix rounds were built
-on is now observed, not inferred). The deployed tg5050 binary was then exercised too (Smart Pro
-S, 2026-07-29 — that platform had never run show2 at all before): it starts with `--hint`,
-creates its FIFO in ~1 s, accepts `TEXT:` and `PROGRESS:` updates and stays alive. **What is
-still unverified: the feature has never run in a real game launch on either device.**
-"Hardware-verified" here means the shell functions behave and show2 draws what it is told; it
-does NOT mean the status screen has been seen driven by a real netplay launch.
-**B skips netplay** (built 2026-07-29): during discovery, pressing B stops the search and
-launches the game single-player for THAT RUN ONLY — launch.sh starts flycast with `-config
-network:GGPO=no`, which flycast keeps as a *virtual* value and never writes back, so `emu.cfg`
-still holds `GGPO = yes` afterwards and the next launch attempts netplay again. B is live from
-the moment the status screen starts until flycast is started, and is honoured at phase
-boundaries, in the discovery loops and inside `nx_fetch`'s watchdog. Bench-verified on the Brick
-2026-07-29, 12/12 checks against the functions extracted verbatim from launch.sh: arm/disarm
-lifecycle, stale-flag clearing, the flag honoured, and `nx_fetch` aborting 2 s into a 30 s
-timeout. The button number is settled on BOTH units: `00`, five consecutive presses each,
-raw `.. .. .. .. 01 00 01 00` on the Brick and identical on the Smart Pro S (2026-07-29), so the
-shared `NX_CANCEL_BTN=00` is right for both and the byte-identical block needs no per-device
-handling. **Still NOT verified, all three needing a real session: (1) an actual B press during a
-real game launch — that it cancels, lands in single-player and leaves `[network] GGPO = yes`
-afterwards; input cannot be injected over adb, so this has never run end to end; (2) any
-two-device pair test with the new block on both units; (3) the cancelled-client-plays-on-its-own
--saves path, which is code-verified and reasoned but never exercised in a real session.**
-Flycast itself was not rebuilt — v2.6 already ships GGPO and DCNet compiled in — but `show2.elf`
-WAS rebuilt on both platforms for the hint line (new optional `--hint`) and is now **deployed to
-both devices** (2026-07-29): Brick md5 2678718c -> 4be3ac43, Smart Pro S fe7d510b -> c943d4b7,
-each md5-verified against the local build, syntax-checked with the device's own shell, and
-`show2.elf` resolves bare via PATH on both. Rollback needs no computer: the pre-change binary is
-kept on-device as `show2.elf.orig` beside it (a second copy lives in the SDD snapshots) — worth
-keeping, since show2.elf is ALSO the first-boot install splash. Remaining deploy for this
-feature = push `overlay_settings.json` to `$SDCARD/Emus/shared/flycast/` + both DC.pak
-`launch.sh` files to their pak dirs on both cards.
+**Status:** Tasks 1-7 (nextui Y-launch, the standalone `netplay.elf` wizard, and the
+rewritten DC.pak `launch.sh`) are built, compile clean on both platforms, and staged
+(not committed). This supersedes the shell-based overlay-toggle flow entirely — see
+`workspace/all/other/flycast/README.md`'s Netplay chapter for what changed and why, and
+`docs/superpowers/specs/2026-07-29-netplay-prelaunch-wizard-design.md` for the design.
+**None of it has been run on real hardware yet** — every item below is a pending
+device check, not a regression from something that used to pass.
+
+Shape of the shipped feature: `Y` on a netplay-capable ROM (Phase 1: DC.pak only,
+marked by a `netplay` file beside its `launch.sh`) writes `/tmp/netplay_launch` and
+launches the pak normally; root Search moved from `Y` to `START`; a "Launch with
+Netplay" context-menu item does the same thing as Y. `DC.pak/launch.sh` sees the flag,
+runs `netplay.elf` (role → hotspot/WiFi → UDP 55441 broadcast discovery / TCP 55440
+handshake → optional rsync save sync on TCP 18731 → `/tmp/netplay_session`), then
+starts flycast with every netplay value as a **virtual** `-config` (`GGPO`,
+`ActAsServer`, `server`, `EnableUPnP`, `device2`) — `emu.cfg` is never written on this
+path. An idempotent migration guard reverts a leftover `GGPO=yes/True` and
+`device2=0` from the old overlay flow on every launch. `--cleanup` (called after the
+game exits, and defensively at the wizard's own startup) tears down any hotspot,
+restores prior WiFi, stops a stray rsyncd, and removes the session file, bounded to a
+19 s budget.
 
 ### On-device verification
 
-- [ ] **Overlay round-trip** — "Netplay" section renders with all 4 items; after toggling
-      and quitting, `emu.cfg` gains the `[network]` keys (`GGPO`/`ActAsServer`/`DCNet` as
-      yes/no, `GGPODelay` as int) and existing `[config]`/`[achievements]` values are not
-      clobbered (flycast rewrites the whole cfgdb on quit).
-- [ ] **GGPO zero-config LAN match (v2 re-run)** — Brick ↔ Smart Pro S, Marvel vs.
-      Capcom 2 (byte-identical chd + `dc_boot.bin` on both cards; wifi on). Overlay:
-      GGPO on on both, Host on exactly one. Launch order is free (see below); a wait
-      of up to 90 s per side is expected while discovery runs, covered by the status
-      screen (measured FIFO-ready and painting in <=1 s on tg5040). A pairing fast
-      enough to beat even that shows the screen only briefly or not at all, which is
-      equally correct. Match must
-      connect with NO manual file copy and NO IP ever typed. Verify `[network]
-      server =` got auto-written on BOTH devices' emu.cfg. (v1 already passed this
-      with host-first ordering — the point of the re-run is that v2 still does.)
-- [ ] **P2 controller** — with netplay on, MvC2's VS mode is selectable and the second
-      device's Start/inputs register as Player 2; confirm `[input] device2 = 0` appears
-      in BOTH devices' emu.cfg. Then toggle netplay off, relaunch, and confirm it went
-      back to `10` (single-player sees a one-pad Dreamcast).
-- [ ] **Launch order is free** — client-role device launched FIRST, host second: they
-      must still pair (this is what v1 could not do).
-- [ ] **Repeat-session fast path** — second run with an unchanged peer IP should pair
-      almost immediately (stored `server =` probe hits before any ping sweep). Only
-      applies on a /24 lease with the stored address inside it; off-subnet or on any
-      non-/24 lease the fast path is skipped by design and the sweep runs.
-- [ ] **Stale peer IP** — change one device's DHCP lease (or edit `server =` to a dead
-      address), relaunch: the sweep must still find the peer and rewrite `server =`.
-- [ ] **Two hosts / two clients** — set both devices to the same role: they must NOT
-      pair (role line mismatch), and both must fail open rather than hang in launch.sh.
-- [ ] **tg5050 serve branch** — RESOLVED 2026-07-28 on-device: Smart Pro S runs
-      busybox 1.35.0 with NO `httpd` and NO `nc` applet; `wget`/`tar`/`ping -W`/
-      `ip`/`wlan0` all verified present, and the fallback serve branch
-      (`python3 -u -m http.server`, python3.10 on firmware) was smoke-tested there
-      (serves, wget round-trip). Remaining on-device item: one session ON the Smart
-      Pro S in each role to exercise the python branch end-to-end in a real launch
-      (both roles now run a server, so the branch is on the client path too).
-- [ ] **Role swap** — after a session, swap Host/join roles and reconnect: the new
-      host's own solo-unlocked content must be what both players see (its REAL card
-      is now the source), not the previous session's borrowed copy.
-- [ ] **Client real-save integrity** — md5 the client's `data/flycast/vmu_save_*`
-      + `dc_nvmem.bin` before and after a full netplay session: byte-identical
-      (client plays entirely in `netplay-data/`).
-- [ ] **Tar guard** — the client extracts the synced tar only when all FIVE conditions
-      hold: non-empty; `tar tf` lists at least one entry (a non-tar payload lists
-      nothing and would pass the negated tests vacuously); every entry is a bare
-      expected NAME (`vmu_save_[A-D][12].bin` / `dc_nvmem.bin`, no slashes, no `..`,
-      no absolute paths); every `tar tvf` mode column is `-`; and no entry is a link
-      (` -> ` — NOT redundant with the mode column, since busybox prints a HARDLINK
-      with a leading `-`; flycast would otherwise write VMU data through a link as
-      root). Bench-verified on the Brick 2026-07-28 (ACCEPT good tar; REJECT
-      path-traversal, symlink, hardlink, non-tar junk, empty) — the on-device item is
-      confirming a hand-crafted bad tar is refused inside a REAL launch and it still
-      falls open.
-- [ ] **Host backup** — after any hosted session: `netplay-backup/` contains
-      pre-session copies of `vmu_save_*.bin` + `dc_nvmem.bin`.
-- [ ] **Wrong-game refusal** — device A on game A, device B on game B: they must NOT
-      pair (netplay-info ROM line mismatch), and each falls open into a normal
-      (failing) GGPO launch after its 90 s scan.
-- [ ] **Fail-open sanity** — one device launched with GGPO on and no peer anywhere:
-      after its 90 s scan it must still reach flycast, never a stall in launch.sh
-      (the status screen should be expected to vanish on whichever message survived —
-      on the client that is "looking for the host..."; on the host it is EITHER
-      "preparing saves..." OR "looking for player 2 on ..." — the host never emits the
-      client's string; the "no ... found - starting anyway" update is queued and then
-      killed with the daemon, so do NOT judge on seeing it). Expect flycast to sit on
-      "Starting Network" (it has no
-      timeout — Cancel is the only exit); that is GGPO's behavior, not a launch.sh
-      hang, and it is what the user sees whenever `server =` is empty or wrong.
-- [ ] **Rollback headroom on Brick** — watch for re-simulation hitches mid-match (GGPO
-      forces SH4 to stock 200 MHz; A53s have limited headroom). If hitchy, Input Delay 2–3.
-- [ ] **Disconnect behavior** — opening the overlay or save/load state mid-match pauses
-      emulation → peer drops after 3 s of silence. Confirm this fails as a clean error/
-      return to gameplay, not a hang.
-- [ ] **DCNet smoke test** — `DCNet = yes` with an online-capable game if one is on hand
-      (ChuChu Rocket, Quake III, PSO); expect the "Connected to DCNet with modem" toast.
-      MvC2 is expected to show nothing (no native online mode). Needs internet, not LAN.
-- [ ] **UPnP off** — launch.sh now writes `[network] EnableUPnP = no` on every GGPO
-      launch, so no hand edit is needed on `.initialized` devices any more. Verify the
-      key is present in BOTH devices' live emu.cfg after a netplay launch, and that no
-      router port-mapping for UDP 19713 appears (flycast defaults UPnP on and leases the
-      mapping for 24 h).
-- [ ] **UPnP on an upgraded install** — start from the real case for every existing
-      device: `EnableUPnP` absent from emu.cfg entirely. Launch with GGPO on and confirm
-      no UDP 19713 mapping appears on the router, in BOTH roles (`ggpo.cpp:801-804`
-      punches the mapping before the `ActAsServer` branch, so host and client both would).
-- [x] **Busy-LAN discovery** — this is where the first real pair test failed, and it took
-      two independent bugs to explain it. Both are fixed and re-verified on the Brick
-      (2026-07-29); the item stays on the list only because the *pair* re-test is still owed.
-      (1) A `/24` ping sweep leaves an ARP entry for every address probed, and this router
-      answers ARP for unused addresses: `ip neigh | grep -c lladdr` went 22 -> **259** across
-      a sweep, decaying back to 22 about 20 s later. One background probe per entry meant
-      ~250 concurrent wgets on a 4-core handheld inside a 4 s collect window. `nx_find_peer`
-      now dedups by MAC before probing (measured 222 -> 16 candidates, peer included).
-      Note busybox `sort -u -k1,1` compares WHOLE LINES and does not dedup by key — awk does it.
-      (2) The decisive one: `nx_fetch` named its download `/tmp/nx_netplay_fetch.$$`, and in
-      POSIX sh `$$` keeps the PARENT shell's pid inside a subshell — verified, parent and both
-      subshell forms all printed 27146 — so every concurrent probe shared one file. One probe's
-      trailing `rm -f` deletes another's payload (16 concurrent probes against a LAN with
-      exactly one real peer returned **zero** hits), and a dead host's `cat` can read a live
-      host's payload and win `ls | sort | head -1` (observed: 192.168.1.14, which refuses
-      connections on 19714, beat the real peer). `nx_fetch` now uses `mktemp` with a
-      URL-derived fallback. The two bugs mask each other: dedup alone cannot fix discovery,
-      and the temp-file fix alone would drown under ~250 probes.
-      The storm is **device-dependent**, and that is what explains why the client found the
-      host but never the reverse. Same LAN, same moment, identical sweep: the Brick goes
-      22 -> **259** neighbours, the Smart Pro S goes 3 -> **13**. So the Smart Pro S spawned
-      few enough probes that the temp-file race still let a hit through occasionally, while
-      the Brick spawned ~250 and never got one. (Mechanism behind 259-vs-13 not established —
-      band/AP or neighbour-table GC — only that it is real and repeatable.) Practical
-      consequence: **bench discovery on the Brick**; the Smart Pro S is not sensitive enough
-      to expose this class of bug.
-      Verification rig, reusable: run a peer on any same-subnet host with
-      `printf 'GAME\nclient\n' > netplay-info && python3 -m http.server 19714`, extract the
-      discovery functions from the deployed launch.sh with awk (one function at a time —
-      overlapping `sed` ranges silently duplicate one-liner bodies like `nx_cancelled`),
-      then call `nx_find_peer client`. Post-fix: 3/3 runs found the peer in 8 s each, on the
-      same LAN that shows 259 phantom neighbours. Misses are still never cached.
-- [ ] **Discovery: known limits accepted, NOT bugs to re-derive** — a review of the 2026-07-29
-      discovery fix raised these; each was checked and consciously left alone. Read this before
-      "fixing" any of them.
-      (a) *MAC dedup can drop the real peer.* `awk '!seen[$1]++'` keeps one IP per MAC in kernel
-      hash order. If the AP answers the sweep's ARP for the peer's own address with the AP's MAC
-      and that reply wins the cache, the peer joins the AP's group and is only probed if it
-      happens to be first in hash order — and it would fail identically every pass for the full
-      90 s. Empirically the peer survived on both devices across 6 runs (last-reply-wins appears
-      to favour the real station). No cheap complete fix exists: probing all ~222 in batches
-      would eat ~64 s of the 90 s budget. Dedup trades completeness for load; at 222 candidates
-      that is the right trade. If this ever does bite, the cheapest mitigation is appending the
-      stored `server =` to the candidate list unconditionally.
-      (b) *Candidates are not filtered to the local /24.* Verified: `10.0.0.5` on a second
-      interface survives dedup and gets probed. Harmless waste on a normal LAN; left alone
-      because filtering must be conditional on `NXP_NET` being non-empty or it would break
-      discovery entirely on a non-/24 lease.
-      (c) *`NETPLAY_DEADLINE=90` is a loop-ENTRY deadline.* Parallelising the probes dropped the
-      per-candidate deadline check, so a pass starting at T+89 still runs its full ~8 s and the
-      `$( )` then waits on stragglers. Real bound is ~90 + 8 + one probe.
-      (d) *`$NXP_HITS` safety rests on an unstated timing margin.* A probe lives <=3 s; the gap
-      from spawn to the next pass's `mkdir -p` is `sleep 4` + `sleep 3` = 7 s. **Invariant: the
-      collect `sleep 4` must exceed `nx_fetch`'s watchdog argument.** Shorten one or raise the
-      other and hits start crossing passes (worst case: one lost pass, ~8 s).
-      (e) *The mktemp fallback is not collision-free in one dormant case* — the same IP on two
-      interfaces with different MACs survives dedup twice and both fallback names are identical.
-      Dormant because `mktemp` is present on both devices, and both probes target the same host
-      so a stolen payload is the right payload.
-      (f) *`ls | sort | head -1` is lexicographic, not numeric* (`.100` < `.20` < `.9`). Fine for
-      the one-real-peer case; with two eligible peers the "same LAN picks the same peer"
-      property is weaker than it sounds, since which IP wins each MAC slot is kernel hash order.
-- [ ] **Two-device pair re-test** — the actual outstanding item: host on one device, client
-      on the other, both on the busy `/24`. Host must reach "found player 2" rather than
-      sitting out the 90 s deadline, and both must clear flycast's Starting Network modal.
-- [ ] **python3 serve branch under the real launch env** — the tg5050 smoke test above
-      ran from a bare adb shell; launch.sh prepends repo-built libs to `LD_LIBRARY_PATH`
-      (tg5050 launch.sh:47). Confirm `python3 -u -m http.server` still starts and serves
-      a fetchable `netplay-info` with that exact environment applied.
-- [ ] **Overlay token after an unclean exit** — toggle GGPO on, then power-cut instead of
-      quitting cleanly; confirm `emu.cfg` still holds `GGPO = yes` (not `True`). A `True`
-      is the one state that would make launch.sh skip the netplay block entirely while
-      flycast itself still enables GGPO — i.e. netplay with no discovery and no sync.
-- [ ] **Filename-mismatch pairing** — the same CHD under two different filenames on the
-      two cards: they must NOT pair (`netplay-info` line 1 is the extension-stripped ROM
-      filename, not a content hash). Confirm the symptom stays thin: the status screen
-      sits for the full 90 s on whichever message survived show2's init window — on
-      the client "looking for the host...", its only pre-wait message; on the host
-      EITHER "preparing saves..." OR "looking for player 2 on ..." — then simply
-      disappears, since the "starting anyway" update is queued and killed before it
-      can be read. Then
-      flycast's untimed "Starting Network" — nothing names the mismatch.
-- [ ] **Local two-pad regression** — with GGPO off, set `[input] device2 = 0` through
-      flycast's OWN Controls UI for local two-pad play, relaunch with GGPO still off, and
-      record that the restore branch reverts it to `10` (it cannot distinguish that value
-      from one this block wrote).
-- [ ] **Server cleanup on a pak kill** — quit through the OSD/power path rather than
-      flycast's own exit, then `netstat -tln | grep 19714`: the cleanup block only runs
-      after `wait $EMU_PID`, so a kill that bypasses it may leave the serve dir listening.
-- [ ] **GGPODelay asymmetry** — set a different Input Delay on each side and confirm it is
-      NOT a desync (`inputSize` depends on `GGPOAnalogAxes`, not on delay), so the "must
-      match" warning stays correctly scoped to `GGPOAnalogAxes` and `device2`.
-- [ ] **No stray listener** — after a normal quit, a crash, and a power-off mid-session:
-      port 19714 must not be listening (`netstat -tln`); the serve dir is LAN-readable
-      for as long as a server lives.
-- [ ] **Dead/duplicate server** — launch either device with 19714 already bound (or
-      double launch): launch.sh must fall open and reach flycast rather than stall.
-      Burning the full 90 s deadline is NOT a failure — a device with no reachable
-      peer always does; the assertion is that the launch proceeds. Note observed
-      behavior. Both roles run a server now, so this applies to host and client alike.
-- [ ] **Upgraded-install cfg creation** — on a real `.initialized` device cfg (no
-      seeded `[network]`, and typically no `[input]` section at all): overlay toggle
-      creates `[network]`, discovery creates `server =` from scratch, and the netplay
-      block creates `[input] device2` from scratch (bench proved the mechanics on a
-      live-shaped cfg, not the live file).
-- [ ] **tg5050 tar guard on hardware** — re-run the five-condition guard cases under
-      Smart Pro S busybox 1.35 tar (the hardlink/mode-column rendering is verified on
-      the Brick's busybox 1.27.2 only).
-- [ ] **Speaker pop on netplay launches** — unmute timer fires at T+5 s but flycast
-      can start up to 90 s later; listen for the pop the mute normally suppresses.
-- [ ] **DCNet + GGPO together** — README claims independence; confirm on-device or
-      document mutual exclusion (DCNet's non-deterministic traffic would desync
-      rollback).
-- [ ] **Non-/24 LAN** — a device on a /16 or /23 lease: neighbor-only scan, clean
-      fail-open, and no self-pairing with its own server (each device now serves one).
-      Now true in a stronger sense: the address is parsed with a `/24`-only `sed`, so
-      off a /24 the subnet comes back empty and the stored `server =` is skipped
-      UNCONDITIONALLY, not just when the octets differ. Consequence to check: a
-      hand-set `server =` is never probed by the FAST PATH there — the `ip neigh` loop
-      still runs, so that host is reachable only if it already sits in the ARP cache,
-      and nothing sweeps to populate that table off a /24. So the client may pull no
-      save tar even though flycast still connects on that address (launch.sh leaves
-      the value alone when discovery finds nothing) — GGPO connects, sync does not.
-- [ ] **Status screen appears** — SETUP MATTERS: run this with the peer absent, or
-      with `[network] server =` cleared on this device first, so the wait is long
-      enough (90 s / >=7 s) to exercise the `TEXT:` update path properly. On the fast
-      path discovery can outrun the screen and either a brief flash or nothing at all
-      is correct — that is the item below, not this one. With this setup, PASS = all
-      three of: (1) a netplay
-      status screen appears; (2) the message on it is ONE OF the literal strings
-      below; (3) the launch proceeds to flycast. ONE EXCEPTION, and it is a FAIL: if
-      `Starting...` is the only thing ever shown for the whole wait, no
-      `TEXT:` update reached the FIFO — that string is show2's own `--text=` argument,
-      painted from the first frame whether or not the update path works at all (a
-      failed `mkfifo` only `perror`s and keeps rendering, `show2.cpp:238-241`; an
-      `nx_ui` subshell that exhausts its 10 s poll budget exits silently,
-      `launch.sh:229`). This is the only item that exercises the `TEXT:`/`PROGRESS:`
-      path *from launch.sh*, on either device (the deployed tg5050 show2 has accepted
-      `TEXT:`/`PROGRESS:` by hand, but nothing has driven it through a real launch
-      there). It cannot false-fail a correct run:
-      with the setup above the wait is >=7 s (cleared `server =`) or 90 s (peer
-      absent), against a 1 s poll and a 10 s budget. Otherwise do NOT require a
-      particular message, or any particular sequence — the design guarantees neither.
-      Expected survivors,
-      by role, quoted exactly as launch.sh emits them (the `Netplay: ` prefix these
-      strings once carried was dropped 2026-07-29 after it read as clipped on hardware —
-      a screen still showing it is running an old launch.sh): CLIENT — `Looking for
-      the host...` (it queues only one pre-wait message). HOST — EITHER `Preparing
-      saves...` OR `Looking for player 2 on <subnet>.x...`, which
-      off a /24 reads `Looking for player 2 on the network...`. Sent but
-      rarely seen: `Starting...` (the daemon's own `--text=`), `Player 2 found at
-      <ip>`, `No player 2 found - starting anyway`,
-      `No host found - starting anyway`. The one terminal message that IS
-      readable is the client's `Host found at <ip> - copying saves...`,
-      which dwells ~1-2 s (the tar fetch of a ~384 KB card over LAN, plus a few `tar`
-      spawns; the 30 s in `nx_fetch` is only the watchdog ceiling for a stalled host).
-      Why the chain is not assertable: (a) each `nx_ui` call polls for the FIFO from
-      its OWN background subshell on an independent `sleep 1` cadence, so among the
-      messages queued before the FIFO exists ANY of them may be the survivor — on the
-      host it can be "preparing saves..." or "looking for player 2 on ...", either
-      way; (b) terminal messages are only queued, and the very next thing launch.sh
-      does is `nx_ui_stop`, whose `killall -9` destroys the daemon within
-      milliseconds — at 60 fps that is ~17 ms (derived, not measured) to paint a frame
-      that is then torn down.
-- [ ] **Fast path — brief screen or none, BOTH correct** — the counterpart to the item
-      above, worth recording deliberately because it is the state a tester will be in
-      by default (every preceding pair test auto-writes `server =` on both devices).
-      Relaunch with a valid stored `server =` and the peer up: the stored probe returns
-      in ~1 s (`nx_fetch` checks `kill -0` BEFORE its first `sleep 1`), so the whole
-      block finishes in roughly 1.5-2.5 s on the host and 2.5-3 s on the client. With
-      init measured at <=1 s the screen will PROBABLY paint briefly and then vanish —
-      but a run where it never appears at all is equally correct. PASS = the launch is
-      fast and reaches flycast; do NOT fail it either way. (This was written when init
-      was estimated at ~3-4 s and predicted a guaranteed black screen; the measurement
-      inverted that prediction, hence the either-outcome wording.) The insight the item
-      exists to record is unchanged: the faster discovery gets, the less the status
-      screen has to show, because there is less wait left to cover. Use the peerless /
-      cleared-`server =` setup of the item above — not this one — to actually exercise
-      the `TEXT:` update path.
-- [ ] **Status screen never outlives the launch** — after flycast starts, confirm no
-      `show2.elf` process remains. Use `pgrep -x show2.elf`. NOT `pgrep -f show2` and
-      NOT a bare `ps | grep show2`: both match the checking shell's own command line
-      and report a phantom hit (this actually fooled a bench session). Check on both
-      roles. Cleanup depends on `killall -9` — see the Gotchas entry; if a plain
-      SIGTERM ever gets restored here, this item is what catches it.
-- [ ] **Degrades silently** — rename `show2.elf`, relaunch: netplay must still work,
-      just without the status screen, and must not stall.
-- [ ] **Relocation is fast** — join a different network so the stored `server =`
-      is on the old subnet; confirm the stale address is skipped (no ~3 s dead
-      probe) and discovery still finds the peer.
-- [ ] **Busy-LAN scan time** — on the 60-AP location, time ONE discovery pass, not a
-      full failed scan: a failed scan is deadline-bound at 90 s under serial and
-      concurrent probing alike, so it cannot tell the two apart. A pass is a fixed
-      ~7 s (3 s sweep settle + 4 s collect) plus the slowest straggler probe, each
-      bounded by the 3 s fetch watchdog — and crucially that figure must NOT grow
-      with the neighbour count. Count the neighbours (`ip neigh | wc -l`) so the
-      "does not scale" claim has a number attached.
-- [ ] **B skips netplay** — wait until the netplay screen is actually up and the
-      "B = skip netplay" hint is visible, THEN press B (pressing during show2's
-      own startup still cancels, but the confirmation cannot be drawn yet because
-      its FIFO does not exist). The screen should change to
-      `Skipped - starting game...` and the game should start
-      single-player within a couple of seconds. Afterwards confirm
-      `[network] GGPO` is STILL `yes` in emu.cfg — the skip is per-run only.
-- [ ] **Cancelled client uses its OWN saves** — cancel on the client role, then
-      check in-game that the VMU content is the client's own, not the host's
-      borrowed copy (netplay isolation is skipped when cancelled).
-- [ ] **B works outside the search too** — press B while the host is preparing
-      saves, and (separately) while the client is copying saves: both must skip.
-- [ ] **Only B cancels** — press A, X, Y, START and move the stick during the
-      search: none may skip netplay.
-- [x] **B is button `00` on BOTH units** — RESOLVED 2026-07-29 on-device: five
-      consecutive presses on the Smart Pro S read `.. .. .. .. 01 00 01 00`,
-      identical to the Brick, so the shared `NX_CANCEL_BTN=00` is correct for both
-      and the byte-identical block needs no per-device handling. Keep the method
-      note if this is ever re-measured: read js0 the way launch.sh does — open once,
-      then `dd bs=8 count=1 <&3 | hexdump`. A buffered `dd | hexdump | while read`
-      pipeline gives WRONG numbers, and that is exactly how the discarded "B = 02"
-      reading was produced — do not "correct" `00` back to it.
-- [ ] **Hint is legible** — both lines visible and unclipped, hint stays put while
-      the status line changes. (Both cards were updated to the `--hint`-capable
-      show2.elf on 2026-07-29, so a missing hint line means something other than an
-      old binary — check the deploy first anyway with `md5sum`: 4be3ac43 on the
-      Brick, c943d4b7 on the Smart Pro S.)
-- [ ] **Leftover input reader clears itself** — on a NON-cancelled netplay launch
-      the reader's `dd`/`hexdump` children outlive `nx_cancel_disarm` by design.
-      Find them with `readlink /proc/*/fd/*` matching `/dev/input/js0` — NOT by
-      cmdline, since the path is a redirection and never appears in argv. Just
-      after the game starts they may still be listed; press any controller button
-      and re-check: they must be gone, because `dd` ran with `count=1`. Confirm
-      in-game input is unaffected while they linger.
-- [ ] **Install splash unaffected** — the deployed show2.elf is also the first-boot
-      splash; run `install/boot.sh`'s invocation (no `--hint`) and confirm it
-      renders as before. Bench-passed pre-deploy on the Brick with boot.sh's exact
-      argument list (starts, FIFO in 1 s, accepts `TEXT:`, log identical to the
-      baseline); this item is the same check against the binary now on the card, on
-      both devices. If it ever fails, `show2.elf.orig` sits beside it on-device.
+- [ ] **Wizard solo, one device (Task 1/2/3/6 bring-up)**
+      — marker present/absent correctly gates the Y hint, the Y branch, and the
+      "Launch with Netplay" context item (present in ROM listings; per Task 1's own
+      notes, unreachable from the context menu at root, though Y itself works there);
+      Y writes `/tmp/netplay_launch` and launches exactly like an A press otherwise;
+      `START` opens root Search where `Y` used to.
+      Every wizard screen renders and `B` backs out one step at a time; `B` on the
+      very first screen exits the wizard (rc=1) and `launch.sh` returns to the game
+      list without ever starting flycast. Invoking `netplay.elf` with no `--game`
+      exits rc=2; `--cleanup` with no session file present is a harmless no-op (rc=0).
+      Hotspot host brings up `NextUI-<code>` and it is joinable from a second device
+      (or a phone); the WiFi picker scans and connects on a real LAN (not just the
+      bench fake-peer rig); a wrong password, then `B`, leaves other networks still
+      selectable. A stale session file left by a simulated kill is healed (hotspot
+      torn down / WiFi restored) before the wizard's very first menu appears.
+- [ ] **Pair test, Brick ↔ Smart Pro S, a netplay-capable DC game (e.g. MvC2), all
+      four quadrants** (host/client × hotspot/WiFi) — from the spec's hardware
+      verification plan plus Task 4/5/7's device items:
+      - pairing completes with no IP ever typed in any quadrant (UDP 55441 broadcast
+        + TCP 55440 handshake, not the old ping sweep).
+      - only hosts broadcasting the *identical* game name appear in the client's
+        list; a deliberately mismatched game/protocol produces a named `REJECT`
+        error on the CLIENT's screen only — it falls back to its host list
+        (WiFi) or exits the wizard (hotspot, nothing else to connect to) — while
+        the HOST shows no error at all: it silently sends `REJECT` and keeps
+        showing "Waiting for player...", by design. Do not expect (or misreport
+        the absence of) a host-side error here.
+      - save sync: client's `netplay-data` copy of `vmu_save_*.bin`/`dc_nvmem.bin`
+        md5-matches the host's real originals after the pull, at WiFi speed; a pull
+        attempted from a third, non-paired IP is refused (rsync `hosts allow`); no
+        `.netplay-staging` directory survives a successful sync; a deliberately
+        failed pull leaves the client's existing saves byte-identical (no partial
+        commit); the progress bar renders correctly at both devices' screen scales.
+      - both devices clear flycast's untimed "Starting Network" modal and P2 inputs
+        work (virtual `device2=0` on both sides).
+      - client's own real saves are untouched after the session (it played entirely
+        out of `netplay-data/`); host's `netplay-backup/` holds its pre-session copy.
+      - after the session, `netstat` shows no listener on 55440/18731 on either
+        device, and `pidof hostapd`/`pidof rsync` are clean.
+- [ ] **Migration regression** — on a card that still has `[network] GGPO = yes` (or
+      `input device2 = 0`) on disk from the old overlay-toggle flow, a plain
+      `A`-launch must fire the guard and go straight to a single-player game — no
+      90 s peer wait — and the on-disk values must now read `GGPO = no` /
+      `device2 = 10`.
+- [ ] **`emu.cfg` untouched by a netplay run** — hash/diff it before and after a full
+      hosted and a full joined session on both devices: no key changes at all (the
+      migration guard's one-time rewrite aside), confirming the five netplay values
+      really are virtual-only.
+- [ ] **Cancel → game list** — cancelling the wizard at any step (before and after
+      network setup has started) returns cleanly to the game list; flycast is never
+      started on a non-zero wizard exit.
+- [ ] **Kill-and-heal** — kill the pak mid-session via the OSD/power path (bypassing
+      `launch.sh`'s own `--cleanup` call) instead of quitting normally, then start a
+      netplay attempt again: the startup self-heal must tear down the orphaned
+      hotspot/rsyncd and restore WiFi before the wizard's first menu, within the
+      19 s teardown budget (`WIZ_TEARDOWN_BUDGET_MS`).
+- [ ] **`sh -n` on-device** — re-check both DC.pak `launch.sh` files with the
+      device's own busybox ash (`adb shell sh -n <path>`); already clean under macOS
+      `sh -n`, but that is not proof against busybox's parser.
 
 ### Gotchas
 
-- `GGPO = yes` persists across quits — every subsequent launch of ANY DC game waits for a
-  netplay peer until it's toggled back off in the overlay. Turn it off after playing.
-  Pressing B to skip does NOT count as turning it off: it disables netplay for that one
-  run through a virtual `-config` value flycast never writes to `emu.cfg`, so the next
-  launch searches again — and `[input] device2` stays at `0` until a launch with GGPO
-  actually off puts it back to `10`.
-- The peer IP (`server =`) is auto-written by launch.sh discovery on both sides, and
-  is probed first on the next launch (fast path) — but ONLY when the device holds a
-  /24 lease AND the stored address is inside it. Off-subnet (after a relocation) or
-  on any non-/24 lease it is skipped entirely, which is what makes those launches
-  fast instead of costing a dead ~3 s probe. Manual emu.cfg edit is a fallback for
-  LANs where the /24 sweep + neighbor probe can't find the peer, with the same
-  caveat: on a non-/24 lease a hand-set value is never probed by the fast path (the
-  `ip neigh` loop still runs, but nothing sweeps to populate that table off a /24,
-  so it only helps if the peer is already in the ARP cache), and flycast may then
-  connect on that address while the client still pulls no save tar.
-- `GGPO = yes` persisting (previous gotcha) now also means the discovery/sync phase
-  (up to 90 s) runs on EVERY DC launch until it's toggled off — one more reason
-  to turn it off after playing. It also means `[input] device2` stays at `0`
-  (port B occupied) until a launch with GGPO off puts it back to `10`.
-- Netplay launches must be plain "A START", never switcher-resume (slot-9 load after
-  GGPO's boot-time start desyncs; the client's slot 9 lives in `netplay-data/` so
-  normal resume is never polluted, but the host's real slot 9 is).
-- **show2 must be killed with `killall -9`, never plain `killall`.** Measured on the
-  Brick 2026-07-29: SIGTERM leaves it alive (still running 6 s later); `-9` kills it
-  instantly. show2 installs a handler for SIGINT only (`show2.cpp:623`), and
-  `SDL_Init` traps SIGTERM into an `SDL_QUIT` event that show2's daemon loop never
-  pumps — so the signal is swallowed. `nx_ui_stop` uses `-9` for this reason, as does
-  `MinUI.pak/launch.sh:228`. Anything that "tidies" it back to a plain `killall`
-  leaves the status screen holding the display against flycast.
+- flycast's GGPO/DCNet internals are unaffected by the wizard rewrite and still hold:
+  GGPO always drives Dreamcast **port B** as player 2, so `device2` must be a real
+  pad on both sides or the second device's inputs reach nothing (port B is empty by
+  default); UPnP is forced off because `ggpo.cpp:801-804` punches a router mapping
+  **before** checking `ActAsServer`, so both roles would otherwise leak an 86400 s
+  lease; `server =` semantics (empty → loopback deadlock, flycast's "Starting
+  Network" modal has no timeout, Cancel is the only exit) are still exactly what a
+  broken pairing looks like at the flycast layer, even though the wizard should now
+  make that unreachable in normal use.
+- **`PerGameVmu` must stay off.** With it on, flycast writes the per-game VMU file as
+  `<gameId>_vmu_save_A1.bin`, which does not match the wizard's `--fetch-files` glob
+  (`vmu_save_*.bin`) any more than it matched the old tar glob — the sync silently
+  ships an incomplete card, with "Peer verification failed" the only symptom.
+- **Switcher-resume desync.** A netplay session must be started as a fresh launch,
+  never a switcher RESUME on a netplay-capable ROM — GGPO's boot-time sync desyncs
+  against a mid-session state load. This used to mean "must be a plain A START"; it
+  is now "must be a plain **Y** START" (or the "Launch with Netplay" context item) —
+  an ordinary switcher resume on a netplay-capable game is exactly what the Y branch
+  exists to bypass, so don't use it to start netplay.
+- **`show2.elf` must still be killed with `killall -9`, never plain `killall`**, if
+  anything ever drives it again — SIGTERM is swallowed (SDL traps it into an
+  `SDL_QUIT` its daemon loop never pumps). This no longer applies to netplay at all
+  (the wizard has its own screens and owns its own process lifecycle); `show2.elf`
+  remains only the first-boot install splash.
+- **Migration guard fires at most once per card**, by construction: it reverts
+  `GGPO=yes/True → no` and `device2=0 → 10` on every launch, but since the new flow
+  never writes either key back to `emu.cfg`, there's nothing left for it to revert
+  after the first post-upgrade launch. A user who deliberately sets `device2 = 0` in
+  flycast's own Controls UI for local two-pad play will have it reverted the one time
+  the old value is still on disk — same accepted ambiguity as the original overlay
+  flow, just incapable of recurring afterward.
+- A stale `server =` (and `EnableUPnP = no`) left in `emu.cfg` by an old, pre-wizard
+  session is harmless and deliberately not swept — flycast only reads it on the GGPO
+  path, where the wizard's virtual value overrides it anyway.
+- **`wizard_wifi.c`'s picker/scan loops don't poll `app_quit`** — up to 120 s
+  (`WIZ_PICKER_TIMEOUT_MS`). This is what makes a SIGTERM-then-SIGKILL while sitting
+  in the WiFi/hotspot picker a real window for an orphaned AP, i.e. exactly the
+  scenario the kill-and-heal check above exists to catch. Tracked as a follow-up in
+  `DEV_TODO.md` (make the loops poll `app_quit`); not fixed in this build.
 
 ---
 

--- a/DEV_TODO.md
+++ b/DEV_TODO.md
@@ -37,6 +37,90 @@ blind (which is how the original masks got here).
 
 ---
 
+## Trimui Brick Pro: joystick calibration (stock-parity)
+
+**Requested:** 2026-07-29, after on-device probing of the stock firmware (v1.1.1) confirmed
+NX's existing calibration cannot work on this model. Stock OS has a "calibrate joystick"
+option, so users migrating to redux will expect one.
+
+**Why NX's current path is a no-op here:** `settings_input.c`'s calibration (entered via
+`L3+R3` in Settings → Input Tester) reads raw ADC packets from the hall-stick MCU serial
+ports `/dev/ttyAS5` / `/dev/ttyAS7` (19200 baud, 19-byte `0xFF…0xFE` packets). The Brick
+Pro has NO `/dev/ttyAS*` nodes at all — its sticks are read by `trimui_inputd` over I2C
+(`/dev/i2c-3`), which synthesizes the `TRIMUI Player1` uinput gamepad.
+
+**The acquisition protocol is fully reverse-engineered and hardware-verified
+(2026-07-29, live device over adb).** Raw ADC does NOT pass through the event device —
+that path was tested and disproved: with the flag set, `js0` emitted ZERO events during
+8 s of continuous stick movement (baseline without the flag: 818 events, full-scale
+−32603…+32727 sweeps). Instead, stock MainUI reads the stick ADCs **directly over I2C**,
+the same way `trimui_inputd` does. Protocol, extracted from the UNSTRIPPED
+`/usr/trimui/bin/trimui_inputd` (`_i2c_read` + `trimui_poll_thread_joy_i2c`) and
+confirmed live with `i2cdetect` (present on the stock firmware at `/usr/sbin/i2cdetect`):
+
+- Bus `/dev/i2c-3`, two ADC chips at 7-bit addresses **0x28 and 0x29** (the binary
+  passes 8-bit 0x50/0x52 and shifts right) — one chip per stick. `i2cdetect -y 3`
+  shows exactly these two and nothing else.
+- Read = `I2C_RDWR` write-then-read pair: write 1 register byte **0xB0**, read
+  **4 bytes** = X then Y, little-endian u16 each, 12-bit range (values sanitized to
+  0–4095; matches the factory config's ~1120–3050 span). inputd sets
+  `I2C_TIMEOUT=5`, `I2C_RETRIES=1`, opens and closes the fd around every poll.
+- Flag semantics (verified live): `/tmp/joypad_testmode` present → inputd SKIPS the
+  poll entirely (also skipped while `/tmp/system_suspend` exists) — it stops feeding
+  uinput AND releases the bus so the calibrator can be sole reader. This is a
+  quiesce flag, not a raw-passthrough mode.
+- Config consume side (from the same disassembly): calibrated output =
+  `(v − zero) * 32760 / (max_or_min − zero)` clamped, a squared-radius circular
+  deadzone (`x² + y² < r²` → 0), and ±0x7f change-hysteresis before an event is
+  emitted. Keys parsed: `x_min/x_max/y_min/y_max/x_zero/y_zero` plus `z_min/z_max`
+  (analog triggers) and `deadzone`.
+
+The downstream contract is shared with the existing serial path: write the same
+`/mnt/UDISK/joypad.config` / `joypad_right.config` files NX already writes (factory
+unit shipped with `joypad.config` = center ~2086/2038, range ~1120–3050, deadzone
+0.10, and NO `joypad_right.config`), then touch `/tmp/trimui_inputd/cal_update` to
+make inputd reload.
+
+**Implementation sketch:** in `settings_input.c`, branch on device (or on the absence
+of `/dev/ttyAS5`): instead of `cal_open_serial()` + packet parsing, touch
+`/tmp/joypad_testmode`, then during the existing range/center capture phases
+(`CAL_RANGE_SECS`/`CAL_CENTER_SECS` UX stays as-is) read both chips via `I2C_RDWR`
+(addr 0x28/0x29, reg 0xB0, 4 bytes → X,Y u16 LE). Write the same two config files,
+`rm` the flag, touch `/tmp/trimui_inputd/cal_update`. Everything but the ~40-line
+sampling function reuses the existing code.
+
+- [x] Chip-to-stick mapping — RESOLVED 2026-07-29 empirically (hold-one-stick sessions
+      with a cross-compiled I2C reader; static disassembly trace agrees):
+      **0x29 = LEFT stick, 0x28 = RIGHT stick.** Direction/wire notes: values are
+      BIG-endian u16 on the wire (inputd `rev16`s them); left stick pushed EAST drove
+      X DOWN (~2011 → ~1090), right stick pushed UP drove Y UP (~2040 → ~3025 ≈
+      factory y_max) — i.e. raw axes are not consistently oriented, but calibration
+      only needs min/max/center so orientation is inputd's problem, not ours. Also
+      observed: this unit's real deflection (1072) EXCEEDS the factory config span
+      (x_min=1120) — live proof per-unit calibration matters. Both sticks' ADCs
+      verified working (bring-up datapoint for the DEV_CHECKLIST "Analog sticks"
+      item). Reader tool: ~50-line `i2cread.c` (open `/dev/i2c-3`, `I2C_RDWR`
+      write-0xB0-read-4 per chip) built with the `ghcr.io/loveretro/tg5040-toolchain`
+      docker image — MUST be linked dynamically: `-static` glibc from that toolchain
+      aborts with `FATAL: kernel too old` on the 4.9 kernel, the exact taskset trap
+      from 2026-07-27. Binary left at `/tmp/i2cread` on the device (tmpfs — gone
+      after reboot); source in the session scratchpad, trivially recreatable from
+      the protocol above.
+- [ ] Implement the brickpro acquisition branch in `settings_input.c` per the sketch.
+- [ ] Decide whether to include trigger (`z_min`/`z_max`) calibration or leave triggers
+      at inputd defaults — and find where trigger raw values come from (possibly a
+      different register on the same chips, or the SoC keyadc; NOT yet traced).
+- [ ] Remove the interim "hide/disable or leave inert" ambiguity: the Brick Pro
+      DEV_CHECKLIST bring-up item now expects `L3+R3` calibration to WORK on this model
+      once this lands.
+
+Evidence artifacts from the probe session (scratchpad, not committed): pulled
+`trimui_inputd` binary, `jsA.bin`/`jsB.bin` js0 captures. Redux install still waiting
+on an SD card; implementation itself is NOT hardware-blocked any more — only the
+stick-to-chip mapping check is.
+
+---
+
 ## Trimui Brick Pro: deferred from the port
 
 Scoped out of the Brick Pro port (`c0da09c7`) on purpose. None of these block the port's

--- a/DEV_TODO.md
+++ b/DEV_TODO.md
@@ -15,6 +15,68 @@ Neither file is a changelog — delete an entry when it lands, don't mark it don
 
 ---
 
+## Netplay wizard: minarch migration
+
+**Recorded:** 2026-07-29, alongside the DC pre-launch wizard build (see
+`DEV_CHECKLIST.md`'s "DC netplay pre-launch wizard" section and
+`docs/superpowers/specs/2026-07-29-netplay-prelaunch-wizard-design.md`'s
+"Minarch follow-up" section). Scoped out of that effort on purpose — DC/flycast
+was Phase 1, minarch is the deliberate follow-up.
+
+Minarch's own netplay (fbneo/fceumm/snes9x/supafaust/picodrive/pcsx + GBA/GB
+link) currently lives entirely in the in-game pause menu (Host/Join, hotspot/WiFi,
+host list) — good UX, but setup happens after the emulator is already running.
+The plan is to move minarch-core paks onto the same `netplay.elf` wizard DC.pak
+now uses, dropping the in-game setup:
+
+- [ ] Minarch-core paks run the wizard with **no sync args** (`--serve-dir`/
+      `--fetch-to`/`--fetch-files` all omitted) — minarch cores don't need the
+      wizard's rsync save sync; whatever save-state handling they already do
+      stays as-is.
+- [ ] Minarch grows a boot-time path: if `/tmp/netplay_session` is present,
+      start the engine directly with `role`/`peer_ip`/`mode` from the session
+      file and **skip the in-game Host/Join menus** entirely. Link type per core
+      is already a static, hardcoded mapping (the existing core-to-link-type
+      table), so it's knowable before launch — nothing new needs designing
+      there.
+- [ ] Drop (or gate off) the in-game Host/Join entry points once the wizard
+      path lands, so there's exactly one way to start a netplay session.
+- [ ] **Open design question, not yet decided:** whether in-session
+      Disconnect/Status survives the menu removal, and if so, where it lives
+      (a slimmed-down pause-menu entry? An overlay toast?). The control channel
+      and session file are already sufficient to support it; this is a UX
+      decision, not a plumbing one.
+
+The wizard's ports (TCP 55440 control channel, UDP 55441 discovery, TCP 18731
+rsync) were deliberately chosen to avoid minarch's existing in-game netplay
+ports (55435-55438, 56400/56421), so both implementations can run side by side
+during this migration — no coordination needed between the two at the network
+level, only at the "which one starts the emulator" level above.
+
+---
+
+## Netplay wizard: `wizard_wifi.c` picker loops don't honor `app_quit`
+
+**Flagged:** Task 6 of the 2026-07-29 netplay pre-launch wizard build (see
+`.superpowers/sdd/2026-07-29-netplay-prelaunch-wizard/task-6-report.md`, §8.6,
+"M7"). Out of scope for that task's fix round since the affected file
+(`workspace/all/netplay-wizard/wizard_wifi.c`) belongs to an earlier task.
+
+`wizard_wifi.c`'s WiFi/hotspot picker and scan loops (`WIZ_PICKER_TIMEOUT_MS`,
+120000 ms) don't poll the `app_quit` flag the rest of the wizard's state
+machine uses to unwind on a caught signal. In practice this means a `SIGTERM`
+followed by a `SIGKILL` while a user is sitting in the picker can take up to
+120 s to be noticed at all — and it's exactly this window that makes an
+orphaned hotspot AP / stray rsyncd a real, reachable failure mode rather than
+a theoretical one, which is why `DEV_CHECKLIST.md`'s netplay section has a
+dedicated kill-and-heal device check.
+
+- [ ] Make the picker/scan loops in `wizard_wifi.c` poll `app_quit` on the same
+      cadence the rest of the wizard does, so a caught signal unwinds promptly
+      instead of running out the full picker timeout.
+
+---
+
 ## N64: pin the unmatched `mupen64plus` threads
 
 **Found:** 2026-07-27 on Smart Pro S (reproduced twice, incl. a real user session).

--- a/DEV_TODO.md
+++ b/DEV_TODO.md
@@ -15,6 +15,108 @@ Neither file is a changelog — delete an entry when it lands, don't mark it don
 
 ---
 
+## nextui: renaming a ROM must update collection records that reference it
+
+**Requested:** 2026-07-30, after on-device verification of the folder-game rename
+(renaming `Multidisc Test` → `mdisk` left `Collections/qq.txt` pointing at the old
+`.m3u` path, so the game silently dropped out of the collection — `getCollection`
+skips lines whose path no longer exists).
+
+`doRename`/`renameRomFiles` (`gamelist.c`) already sweep saves, states and art to the
+new basename, but never touch `Collections/*.txt`. Fix: after a successful rename, scan
+every `Collections/*.txt` for lines referencing the renamed entry and rewrite them
+in place.
+
+- [ ] Plain ROM rename: rewrite lines whose SD-relative path matches the old rom path
+      (the collection stores the exact path `addRomToCollectionFile` wrote).
+- [ ] Folder-game rename: the collection line points at the folder-named cue/m3u
+      INSIDE the folder, so two path components change
+      (`/Roms/DC/Old/Old.m3u` → `/Roms/DC/New/New.m3u`) — match on the old folder
+      prefix + old basename, not string equality alone.
+- [ ] Check `Collections/map.txt` (display-alias map, see `content.c`'s map handling)
+      for path-keyed entries and rewrite those too if they exist.
+- [ ] Same sweep on DELETE is the natural sibling (prune lines referencing the deleted
+      rom/folder) — decide whether to include it while in there; today a delete also
+      leaves dangling collection lines, they're just invisible because
+      `getCollection` filters non-existent paths.
+
+**Recorded:** 2026-07-30, found during review of the folder-game context-menu change.
+
+`gamelist.c`'s BTN_A branch reads `entry->type` after `Entry_open(entry)` (around
+`gamelist.c:985`). `Entry_open` → `openDirectory` can free the whole directory stack on
+its non-direct-subdirectory path (`launcher.c:512`), leaving `entry` dangling — the same
+defect class the folder-game change fixed at its two netplay sites with a
+`bool was_dir = entry->type == ENTRY_DIR;` snapshot taken before the call. Apply the same
+one-line snapshot here.
+
+- [ ] Snapshot `entry->type` before `Entry_open` in the BTN_A branch; audit the rest of
+      `gamelist.c` for any other `entry` deref after `Entry_open`/`openDirectory`.
+
+---
+
+## Pre-launch options: N64 + minarch adoption
+
+**Recorded:** 2026-07-29, alongside the DC pre-launch options build (see
+`DEV_CHECKLIST.md`'s "Dreamcast pre-launch options" section and
+`docs/superpowers/specs/2026-07-29-dc-prelaunch-options-design.md`). Scoped out of
+that effort on purpose — flycast/DC was the first adopter, everything else is the
+deliberate follow-up.
+
+The mechanism is already generic: `options.elf` is schema-driven, nextui's
+context-menu probe and the `Emulator Settings` picker both key off nothing but
+"does this pak ship an `options.sh`", and no part of either is flycast-specific.
+Adopting an emulator is therefore adding an `options.sh` plus whatever the
+emulator's own config storage needs.
+
+- [ ] **N64 (`N64.pak`)** — the smaller of the two, and mostly already in place:
+      the schema exists (`skeleton/EXTRAS/Emus/shared/mupen64plus/overlay_settings.json`,
+      `config_section = Video-GLideN64`, config file `mupen64plus.cfg`), and
+      mupen64plus takes command-line config overrides as
+      `--set Section[KEY]=VALUE` — which `launch.sh` already uses for the audio rate
+      (`AUDIO_OVERRIDE`, tg5040 `launch.sh:125`). So the work is: an `options.sh`
+      (with a `# NAME:` line so the Emulator Settings picker labels it, modeled on
+      `skeleton/EXTRAS/Emus/tg5040/DC.pak/options.sh`), the same `nx_paths.sh`-style
+      split of config-dir resolution + seeding out of `launch.sh`, and an awk step
+      emitting `--set Sec[KEY]=v` instead of `-config sec:key=v`.
+      **Verify before relying on it:** that `--set` is a virtual/runtime override
+      and mupen64plus does not write those values back into `mupen64plus.cfg` on
+      exit. flycast's `-config` is explicitly virtual (`cfgSetVirtual`); if
+      mupen64plus persists instead, the whole point of the design is lost and the
+      per-game half needs another mechanism (write-launch-restore is NOT acceptable —
+      that is exactly the config-rewriting problem this avoids), leaving
+      global-mode-only as the honest fallback for N64.
+- [ ] **minarch cores** — much harder than N64, and **not** a copy of DC's
+      `options.sh`. Two real obstacles, both worth settling before any code:
+      1. *Storage.* minarch already has its own layered config and its own per-game
+         tier — `Config_getPath` (`ma_config.c:1113`) writes either
+         `minarch[-device].cfg` (console) or `<alt_name>[-device].cfg` (that one
+         game), read on top of a system cfg and the pak's default cfg. Per-game
+         values must go into that existing game-tier file, not a new override INI, so
+         an adapter has to translate both directions — or `options.elf` grows a
+         second storage backend. The *convention* is at least shared: minarch collapses
+         a folder-m3u game's discs to one key too (`ma_game.c:110-136`). The strings
+         differ, though — minarch's `alt_name` keeps the extension (`Game.m3u` →
+         `Game.m3u[-device].cfg`) where `nx_rom_base()` drops it (`Game`) — so an
+         adapter still has to translate the filename, not just reuse it.
+      2. *Schema.* minarch's option list is **not** static: `config.core.options` is
+         filled in by the core at runtime via `RETRO_ENVIRONMENT_SET_CORE_OPTIONS`
+         (`ma_environment.c:227`). A hand-written JSON schema per core would drift
+         silently, so a pre-launch editor needs either a generated/cached schema (dump
+         it on first launch from the live core, then edit against the cache) or to
+         `dlopen` the core just to enumerate — neither of which the DC path had to
+         solve. This, not the shell plumbing, is the actual piece of work.
+- [ ] **Hide the in-game entry last, not first.** Only once an emulator's per-game
+      path actually works should its `launch.sh` export
+      `EMU_OVERLAY_HIDE_OPTIONS=1` — the gate is per-pak (`emu_overlay.c`'s
+      `hide_options`), so a half-adopted emulator that hides in-game Options while its
+      pre-launch editor can't set per-game values leaves users with no way to change
+      anything. Note the env var only covers the two shared-overlay emulators
+      (flycast and mupen64plus, via `flycast.patch` / `GLideN64-standalone.patch`);
+      minarch does not use `emu_overlay.c` at all, so retiring **its** in-game options
+      screen is a separate change in minarch's own menu code.
+
+---
+
 ## Netplay wizard: minarch migration
 
 **Recorded:** 2026-07-29, alongside the DC pre-launch wizard build (see
@@ -207,4 +309,22 @@ hardware bring-up (that checklist lives in `DEV_CHECKLIST.md`).
       by side. **Blocked on an asset:** a 1024×768 pair does not exist anywhere in the
       repo. Until one is produced the file correctly stays in `common/`, since there is
       only one variant to ship.
+
+---
+
+## DC pre-launch options: no launch transition into the editor (cosmetic)
+
+**Recorded:** 2026-07-30, noted while moving the pre-launch options gotchas into
+`workspace/all/other/flycast/README.md`.
+
+Opening "Emulator Options" from the game-list context menu doesn't play the
+usual into-game transition. `gamelist.c`'s case 36 (the pre-launch editor
+launch) doesn't set nextui's `startgame` flag, so the screen-blank-out at
+`nextui.c:265-268` is skipped and the game list stays visible until the editor
+draws over it. Cosmetic only — decide on-device how it actually looks before
+choosing whether it's worth setting the flag (which would blank the screen on
+the way in, matching a normal launch).
+
+- [ ] On device, watch the transition into the editor from the context menu and
+      decide whether to set `startgame` in `gamelist.c` case 36.
 

--- a/Makefile
+++ b/Makefile
@@ -170,6 +170,10 @@ endif
 	# for tg5040/tg5050 (see workspace/Makefile).
 	cp ./workspace/all/netplay-wizard/build/$(PLATFORM)/netplay.elf ./build/SYSTEM/$(PLATFORM)/bin/
 
+	# Pre-launch emulator options editor (run bare off PATH by options.sh and
+	# the Emulator Settings tool)
+	cp ./workspace/all/emu-options/build/$(PLATFORM)/options.elf ./build/SYSTEM/$(PLATFORM)/bin/
+
 ifeq ($(PLATFORM), tg5040)
 	# liblz4 for Rewind support
 	cp -L ./workspace/all/minarch/build/$(PLATFORM)/liblz4.so.1 ./build/SYSTEM/$(PLATFORM)/lib/

--- a/Makefile
+++ b/Makefile
@@ -165,6 +165,11 @@ endif
 	# RetroAchievements tools pak
 	cp ./workspace/all/ratools/build/$(PLATFORM)/ratools.elf ./build/EXTRAS/Tools/$(PLATFORM)/RetroAchievements.pak/
 
+	# Dreamcast netplay pre-launch wizard (run bare off PATH by DC.pak/launch.sh);
+	# gated here, not with the other SYSTEM bin copies, because it is only built
+	# for tg5040/tg5050 (see workspace/Makefile).
+	cp ./workspace/all/netplay-wizard/build/$(PLATFORM)/netplay.elf ./build/SYSTEM/$(PLATFORM)/bin/
+
 ifeq ($(PLATFORM), tg5040)
 	# liblz4 for Rewind support
 	cp -L ./workspace/all/minarch/build/$(PLATFORM)/liblz4.so.1 ./build/SYSTEM/$(PLATFORM)/lib/

--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@ Refer to the Youtube Video below for demonstration of the features:
 ## Supported Devices
 
 - **Trimui Brick**
-- **Trimui Brick Pro**
-- **Trimui Smart Pro**
+- **Trimui Brick Hammer**
+- **Trimui Brick Pro** 
 - **Trimui Smart Pro S**
+- **Trimui Smart Pro** (It should work in theory, but I can't confirm it because I don't have the device to test)
 
 ## Why Fork?
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ New Features:
         - On the game's first launch the pack is converted into a cache in `Roms/Nintendo 64 (N64)/.cache/` with an on-screen progress display — large packs take several minutes and need extra free space on the SD card (e.g. a 2.6 GB pack produces a ~450 MB cache). Later launches load straight from the cache and start fast.
 - Bundled `Flycast Sega Dreamcast` emulator.
     - Runs out of the box without a BIOS (HLE boot); drop `dc_boot.bin` into `Bios/DC/` on the SD card to boot through the real BIOS instead.
+    - GGPO netplay for Dreamcast games: press `Y` on a supported game in the list (or use the "Launch with Netplay" option) to host or join over Wi-Fi or a device-hosted hotspot — no manual IP entry, no persistent toggle to remember to turn back off, and save data is synced automatically before the match starts.
 - Bundled `Portmaster` in the Tools.
     - Configured by default with Nintendo input layout (configurable)
 - Added [Netplay](https://github.com/mohammadsyuhada/nextui-netplay) for local wireless multiplayer, available from the in-game menu.

--- a/skeleton/EXTRAS/Emus/shared/flycast/overlay_settings.json
+++ b/skeleton/EXTRAS/Emus/shared/flycast/overlay_settings.json
@@ -75,20 +75,6 @@
       "ini_section": "network",
       "items": [
         {
-          "key": "GGPO",
-          "label": "GGPO Netplay",
-          "description": "2P rollback play; peer and state auto-discovered on the LAN",
-          "type": "bool",
-          "default": false
-        },
-        {
-          "key": "ActAsServer",
-          "label": "Host (Player 1)",
-          "description": "On = host as Player 1 (your saves are used); Off = join as P2",
-          "type": "bool",
-          "default": false
-        },
-        {
           "key": "GGPODelay",
           "label": "Input Delay",
           "description": "Frames of input delay; higher = fewer rollback hitches",

--- a/skeleton/EXTRAS/Emus/shared/flycast/overlay_settings.json
+++ b/skeleton/EXTRAS/Emus/shared/flycast/overlay_settings.json
@@ -69,6 +69,42 @@
           "default": false
         }
       ]
+    },
+    {
+      "name": "Netplay",
+      "ini_section": "network",
+      "items": [
+        {
+          "key": "GGPO",
+          "label": "GGPO Netplay",
+          "description": "2P rollback play; peer and state auto-discovered on the LAN",
+          "type": "bool",
+          "default": false
+        },
+        {
+          "key": "ActAsServer",
+          "label": "Host (Player 1)",
+          "description": "On = host as Player 1 (your saves are used); Off = join as P2",
+          "type": "bool",
+          "default": false
+        },
+        {
+          "key": "GGPODelay",
+          "label": "Input Delay",
+          "description": "Frames of input delay; higher = fewer rollback hitches",
+          "type": "cycle",
+          "values": [0, 1, 2, 3, 4, 5],
+          "labels": ["0 (off)", "1", "2", "3", "4", "5"],
+          "default": 0
+        },
+        {
+          "key": "DCNet",
+          "label": "DCNet Online",
+          "description": "Online-service relay for games with native online modes",
+          "type": "bool",
+          "default": false
+        }
+      ]
     }
   ]
 }

--- a/skeleton/EXTRAS/Emus/tg5040/DC.pak/default-brick.cfg
+++ b/skeleton/EXTRAS/Emus/tg5040/DC.pak/default-brick.cfg
@@ -23,6 +23,14 @@ fullscreen = yes
 width = 1024
 height = 768
 
+[network]
+GGPO = no
+ActAsServer = no
+GGPODelay = 0
+DCNet = no
+EnableUPnP = no
+server =
+
 [achievements]
 Enabled = no
 HardcoreMode = no

--- a/skeleton/EXTRAS/Emus/tg5040/DC.pak/default-brickpro.cfg
+++ b/skeleton/EXTRAS/Emus/tg5040/DC.pak/default-brickpro.cfg
@@ -23,6 +23,14 @@ fullscreen = yes
 width = 1024
 height = 768
 
+[network]
+GGPO = no
+ActAsServer = no
+GGPODelay = 0
+DCNet = no
+EnableUPnP = no
+server =
+
 [achievements]
 Enabled = no
 HardcoreMode = no

--- a/skeleton/EXTRAS/Emus/tg5040/DC.pak/default-smartpro.cfg
+++ b/skeleton/EXTRAS/Emus/tg5040/DC.pak/default-smartpro.cfg
@@ -23,6 +23,14 @@ fullscreen = yes
 width = 1280
 height = 720
 
+[network]
+GGPO = no
+ActAsServer = no
+GGPODelay = 0
+DCNet = no
+EnableUPnP = no
+server =
+
 [achievements]
 Enabled = no
 HardcoreMode = no

--- a/skeleton/EXTRAS/Emus/tg5040/DC.pak/launch.sh
+++ b/skeleton/EXTRAS/Emus/tg5040/DC.pak/launch.sh
@@ -114,30 +114,16 @@ nx_pick_audio_rate() {
 # Dreamcast AICA is natively 44.1 kHz
 export NX_AUDIO_RATE=$(nx_pick_audio_rate 44100)
 
-# --- Netplay auto-sync + auto-discovery (GGPO) -------------------------
-# Runs only when [network] GGPO = yes in emu.cfg (the overlay's Netplay
-# section). BOTH devices serve a role-tagged netplay-info on TCP 19714
-# and BOTH scan the LAN for a peer running the same ROM in the OPPOSITE
-# role, because GGPO is peer-to-peer: each side must know the other's
-# address (ggpo.cpp:579-597 -- an empty server= makes flycast target
-# loopback on localPort ^ 1: 19712 from the host, 19713 from the client,
-# then wait forever on "Starting Network", which has no timeout, only a
-# Cancel button). v1 had the host learn the client's IP
-# passively from its own access log inside a pre-launch window; a client
-# that was late, absent, or launched first left the host hung. Scanning
-# on both sides makes launch order and timing irrelevant.
-#   host   - plays on its REAL VMU/flash and also serves a tar of exactly
-#            the GGPO-hashed files (vmu_save_*.bin + dc_nvmem.bin, see
-#            ggpo.cpp:537), so whoever hosts contributes their own saves
-#   client - pulls that tar into an isolated netplay-data dir and plays
-#            on the borrowed copy; its own saves are never touched
-# Every failure path falls through to a normal launch ("fail-open").
-# Design: docs/superpowers/specs/2026-07-28-netplay-state-sync-design.md
-NETPLAY_PORT=19714
-NETPLAY_SRV=/tmp/nx_netplay
-NETPLAY_LOG=/tmp/nx_netplay.log
-NETPLAY_DEADLINE=90
-NX_HTTPD_PID=""
+# --- Netplay (pre-launch wizard) ---------------------------------------
+# Netplay runs only when nextui wrote /tmp/netplay_launch (Y / "Launch
+# with Netplay" on a capable ROM). netplay.elf owns all setup UI: role,
+# hotspot/WiFi, peer discovery, and the rsync save sync (host serves its
+# VMU/flash read-only on TCP 18731; the client pulls into netplay-data).
+# Every netplay value below is passed as a VIRTUAL -config: flycast's
+# get_entry() prefers virtual values and ConfigFile::save() never writes
+# them, so emu.cfg is untouched by a netplay run. GGPODelay/DCNet remain
+# real overlay settings that flycast reads from emu.cfg itself.
+# Design: docs/superpowers/specs/2026-07-29-netplay-prelaunch-wizard-design.md
 
 # Read one key from one section of emu.cfg (empty when absent).
 nx_cfg_get() {
@@ -155,554 +141,83 @@ nx_cfg_set() {
     sed -i "/^\[$1\]/,/^\[/s|^$2 =.*|$2 = $3|" "$EMU_CFG"
 }
 
-# wget with a watchdog: busybox wget has no timeout flag, so kill it
-# ourselves after $2 seconds. Prints fetched content (empty on failure).
-nx_fetch() {
-    # Each discovery pass runs a dozen-plus nx_fetch calls CONCURRENTLY,
-    # and in POSIX sh `$$` keeps the PARENT shell's pid inside a subshell
-    # -- so a pid-derived name is the SAME file in every probe. Measured
-    # on-device: 16 concurrent probes against a network with exactly one
-    # real peer returned ZERO hits, because one probe's trailing `rm -f`
-    # deleted the payload another had just downloaded; the same race also
-    # made a dead host report a live host's payload and win the `ls |
-    # sort | head -1` selection. Both present as "stuck looking for
-    # player 2", and this is the other half of the first pair test's
-    # failure: fixing it ALONE would still have been swamped by the ~250
-    # concurrent probes the un-deduplicated neighbour list produced (see
-    # nx_find_peer). Both fixes are required.
-    #
-    # The name must be unique per invocation. mktemp is at
-    # /bin/mktemp on both devices; the fallback derives uniqueness from
-    # the URL, which is likewise distinct for every concurrent probe.
-    NXF_OUT=$(mktemp /tmp/nx_netplay_fetch.XXXXXX 2>/dev/null)
-    if [ -z "$NXF_OUT" ]; then
-        NXF_OUT=/tmp/nx_netplay_fetch.$(printf '%s' "$1" | tr -c 'a-zA-Z0-9' '_')
-        rm -f "$NXF_OUT"
-    fi
-    wget -q -O "$NXF_OUT" "$1" 2>/dev/null &
-    NXF_PID=$!
-    NXF_T=0
-    while [ "$NXF_T" -lt "$2" ]; do
-        kill -0 "$NXF_PID" 2>/dev/null || break
-        # Abort promptly on cancel: without this a press during the
-        # client's up-to-30s tar download would sit unnoticed until the
-        # download finished. Callers already treat an empty result as a
-        # failed fetch.
-        nx_cancelled && break
-        sleep 1
-        NXF_T=$((NXF_T+1))
-    done
-    kill "$NXF_PID" 2>/dev/null
-    wait "$NXF_PID" 2>/dev/null
-    cat "$NXF_OUT" 2>/dev/null
-    rm -f "$NXF_OUT"
+# Migration guard (idempotent): revert the two keys the old overlay-toggle
+# flow persisted that would still CHANGE a plain launch on an upgraded
+# card -- GGPO (would start netplay unasked) and device2 (would plug a
+# phantom pad into DC port B). This is deliberately NOT a full netplay-state
+# wipe: a stale `server = <ip>` (and `EnableUPnP = no`) written by a previous
+# real session is left in emu.cfg untouched. Both are harmless -- flycast
+# reads them only on the GGPO path, and on that path the virtual -config set
+# below overrides them anyway, since get_entry() prefers virtual values.
+# device2: a hand-set 0 (local two-pad) is indistinguishable from the old
+# block's and gets reverted ONCE; the new flow never writes it to disk.
+NX_G="$(nx_cfg_get network GGPO)"
+if [ "$NX_G" = "yes" ] || [ "$NX_G" = "True" ]; then
+    nx_cfg_set network GGPO no
+fi
+[ "$(nx_cfg_get input device2)" = "0" ] && nx_cfg_set input device2 10
+
+# Both early exits below leave the script BEFORE `wait $EMU_PID`, skipping
+# the teardown at the bottom -- and sleepmon.elf, the unmute subshell
+# ($SYNC_PID) and the pre-launch mute are all started ABOVE this block. An
+# orphaned sleepmon.elf left running in the game list keeps its own
+# long-press power handler armed (killall -TERM nextui.elf, then an
+# unconditional poweroff), so an early exit MUST undo them itself. The old
+# netplay block never exited early -- even its cancel arm fell through to
+# flycast, so the teardown at the bottom always ran.
+nx_netplay_bail() {
+    killall sleepmon.elf 2>/dev/null || true
+    kill $SYNC_PID 2>/dev/null || true
+    echo 0 > /sys/class/speaker/mute 2>/dev/null || true
+    exit 0
 }
 
-# --- status display -----------------------------------------------------
-# Drives show2.elf (already shipped in $SYSTEM_PATH/bin) in daemon mode so
-# the long discovery phase is not a silent black screen. show2 renders via
-# SDL2/DRM -- /dev/fb0 is NOT the display path on these devices, so a
-# framebuffer-writing helper would draw nothing. Every call here is a
-# guarded no-op when show2.elf is missing or its daemon died: discovery and
-# launch must never block or fail because of the UI.
-NX_UI_FIFO=/tmp/show2.fifo
-NX_UI_ON=""
-
-NX_CANCEL_FLAG=/tmp/nx_netplay_cancel
-NX_CANCEL_BTN=00          # physical B. Measured on a Brick 2026-07-29:
-                          # five presses, all "01 00 01 00" (value 0001,
-                          # type 01, number 00). Agrees with this pak's own
-                          # SDL_Xbox 360 Controller.cfg (bind0 = 0:btn_b).
-NX_CANCEL_PID=""
-NX_CANCELLED=""
-
-nx_ui_start() {
-    # Resolved via PATH ($SYSTEM_PATH/bin), exactly like this script's own
-    # bare sleepmon.elf / syncsettings.elf / taskset calls. Do NOT build a
-    # $SDCARD_PATH/.system/<platform>/bin path here: that differs per device
-    # and this block must stay byte-identical across both launch.sh files.
-    command -v show2.elf >/dev/null 2>&1 || return 0
-    rm -f "$NX_UI_FIFO"
-    # show2 needs libSDL2 from $SDCARD_PATH/.system/<platform>/lib, which
-    # launch.sh already put on LD_LIBRARY_PATH above; without it show2
-    # aborts with "libSDL2-2.0.so.0: cannot open shared object file".
-    # --image is mandatory but we have no netplay artwork; /dev/null is the
-    # repo's existing "no logo" idiom (see PortMaster's progressor).
-    # --progress=-1 selects show2's indeterminate marquee (show2.cpp:424),
-    # which is what the install boot.sh uses for exactly this kind of
-    # unknown-length wait -- an empty 0% bar would just look stalled.
-    if [ -n "$2" ]; then
-        show2.elf --mode=daemon --image=/dev/null --bgcolor=0x000000 \
-            --progress=-1 --text="$1" --hint="$2" >/dev/null 2>&1 &
+NETPLAY_ARGS=""
+if [ -f /tmp/netplay_launch ]; then
+    rm -f /tmp/netplay_launch
+    netplay.elf --game "$EMU_OVERLAY_GAME" \
+        --serve-dir "$USERDATA_DIR/data/flycast" \
+        --fetch-to "$USERDATA_DIR/netplay-data/flycast" \
+        --fetch-files "vmu_save_*.bin,dc_nvmem.bin" \
+        &> "$LOGS_PATH/netplay-wizard.txt"
+    if [ $? -ne 0 ]; then
+        # cancelled or failed: back to the game list, never a peerless
+        # GGPO launch (single-player is one A press away)
+        nx_netplay_bail
+    fi
+    # Defensive: exit 0 is the wizard's "start with netplay" contract and it
+    # unlinks a half-written session before failing, so a missing file here
+    # is an anomaly -- but sourcing an absent file is FATAL in ash, which
+    # would take the whole launch down. Bail to the game list instead.
+    [ -f /tmp/netplay_session ] || nx_netplay_bail
+    . /tmp/netplay_session
+    if [ "$NETPLAY_ROLE" = "host" ]; then
+        # host plays on its REAL VMU/flash ("host brings the memory
+        # card"); keep a one-deep pre-session copy for manual recovery,
+        # overwritten every hosted session
+        mkdir -p "$USERDATA_DIR/netplay-backup"
+        cp -f "$USERDATA_DIR/data/flycast"/vmu_save_*.bin \
+              "$USERDATA_DIR/data/flycast/dc_nvmem.bin" \
+              "$USERDATA_DIR/netplay-backup/" 2>/dev/null
+        NX_AS_SERVER=yes
     else
-        show2.elf --mode=daemon --image=/dev/null --bgcolor=0x000000 \
-            --progress=-1 --text="$1" >/dev/null 2>&1 &
-    fi
-    NX_UI_ON=$!
-    # Daemon needs ~3-4s (SDL2 + DRM init) before it paints; do not wait
-    # for it here -- the network work below overlaps that cost.
-}
-
-# nx_ui "<message>" [progress 0-100]
-# Opening a FIFO for writing BLOCKS until a reader attaches, so a daemon
-# that died while leaving its FIFO node behind would hang the launch
-# forever on the next status update -- the exact failure this feature
-# exists to prevent. Two defences: skip when the daemon PID is gone, and
-# do the write in a background subshell so even a lost race can only
-# strand that subshell, never the script.
-nx_ui() {
-    [ -n "$NX_UI_ON" ] || return 0
-    kill -0 "$NX_UI_ON" 2>/dev/null || return 0
-    # show2 creates the FIFO only after its SDL2/DRM init: mkfifo is the
-    # first statement of runDaemonMode(), which runs after initialize()
-    # returns (~3-4s). A plain [ -p ] test here would therefore DROP every
-    # early message -- and those are the ones that matter, because the next
-    # update can be up to NETPLAY_DEADLINE seconds later. So wait for the
-    # node, but do it INSIDE the background subshell so the script itself
-    # never stalls. Ordering between messages queued during that init
-    # window is not guaranteed; they all land within a second of each
-    # other and only the last is visible, which is acceptable here.
-    ( NXU_T=0
-      while [ ! -p "$NX_UI_FIFO" ] && [ "$NXU_T" -lt 10 ]; do
-          kill -0 "$NX_UI_ON" 2>/dev/null || exit 0
-          sleep 1
-          NXU_T=$((NXU_T+1))
-      done
-      [ -p "$NX_UI_FIFO" ] || exit 0
-      printf 'TEXT:%s\n' "$1" > "$NX_UI_FIFO" 2>/dev/null
-      [ -n "$2" ] && printf 'PROGRESS:%s\n' "$2" > "$NX_UI_FIFO" 2>/dev/null
-      : ) &
-    return 0
-}
-
-nx_ui_stop() {
-    [ -n "$NX_UI_ON" ] || return 0
-    # Same blocking hazard as nx_ui, and worse here: this is the LAST
-    # statement before flycast launches, so a dead daemon that left its
-    # FIFO node behind would hang the launch at the finish line. Guard on
-    # liveness and background the write. killall is the real cleanup --
-    # it cannot block -- and the QUIT is only the graceful path.
-    if kill -0 "$NX_UI_ON" 2>/dev/null && [ -p "$NX_UI_FIFO" ]; then
-        ( printf 'QUIT\n' > "$NX_UI_FIFO" 2>/dev/null ) &
-    fi
-    # Belt-and-braces: nothing may hold the display against flycast.
-    # MUST be -9. Measured on a Brick 2026-07-29: after a plain SIGTERM the
-    # daemon was still alive 6 s later; SIGKILL ended it instantly. show2
-    # installs a handler for SIGINT only (show2.cpp:623) and SDL_Init traps
-    # SIGTERM into an SDL_QUIT event that show2 never pumps (it has no
-    # SDL_PollEvent at all), so SIGTERM is swallowed. MinUI.pak's own
-    # launch.sh:228 has always used -9 on this same binary.
-    killall -9 show2.elf 2>/dev/null
-    # Leave no stale node for the next launch to trip over.
-    rm -f "$NX_UI_FIFO" 2>/dev/null
-    NX_UI_ON=""
-    return 0
-}
-
-# --- cancel (press B to skip netplay) ----------------------------------
-# True once the user has asked to skip netplay.
-nx_cancelled() { [ -f "$NX_CANCEL_FLAG" ]; }
-
-# Watch the gamepad for a B press and drop a flag file.
-#
-# js0 delivers 8-byte events: u32 time, s16 value, u8 type, u8 number. A
-# real press is type 01 with a non-zero value; opening the device emits an
-# init burst (type 81/82, value 0) and releases carry value 0, so neither
-# can trigger a cancel, and stick movement (type 02) cannot either.
-#
-# Two shapes were tried on-device and BOTH failed; do not "simplify" back
-# to either:
-#   dd if=js0 | hexdump | while read   -- hexdump BLOCK-BUFFERS to a pipe,
-#     so presses sit unseen until ~4KB (~170 events) accumulates. A 45s
-#     capture recorded zero presses while buttons were being pressed.
-#   dd if=js0 count=1 inside a loop    -- re-opens the device every pass,
-#     replaying the init burst each time, and spins.
-# What works: open ONCE on fd 3, then one short-lived dd/hexdump per event
-# so hexdump exits (and therefore flushes) every time. Verified: presses
-# appear immediately and the loop blocks without spinning when idle.
-#
-# od is not on this firmware; hexdump is. Backgrounded so it can never
-# delay the launch. If js0 is unreadable the subshell exits at once and
-# cancel is simply unavailable -- every other path is unchanged.
-nx_cancel_arm() {
-    rm -f "$NX_CANCEL_FLAG"
-    [ -r /dev/input/js0 ] || return 0
-    (
-        exec 3< /dev/input/js0 || exit 0
-        while :; do
-            NXB_EV=$(dd bs=8 count=1 <&3 2>/dev/null | hexdump -v -e '8/1 "%02x " "\n"')
-            [ -n "$NXB_EV" ] || exit 0
-            set -- $NXB_EV
-            [ "$7" = "01" ] || continue
-            [ "$8" = "$NX_CANCEL_BTN" ] || continue
-            [ "$5$6" = "0000" ] && continue
-            : > "$NX_CANCEL_FLAG"
-            exit 0
-        done
-    ) &
-    NX_CANCEL_PID=$!
-    return 0
-}
-
-# Stop watching.
-#
-# Killing the subshell does NOT reap its children: the blocked dd, the
-# command-substitution child and hexdump each keep js0 open. That leak is
-# deliberately accepted rather than swept, and the reasoning is worth
-# keeping because both obvious sweeps are wrong here:
-#
-#   - Matching /proc/<pid>/cmdline cannot work. The device is opened with
-#     `exec 3< /dev/input/js0` and read with `dd bs=8 count=1 <&3`, so the
-#     path is a redirection, never an argument -- busybox ps shows the dd
-#     as "dd bs 8 count 1". Verified on-device: an argv sweep finds none of
-#     the holders.
-#   - Matching open descriptors (readlink /proc/<pid>/fd/*) DOES find them
-#     all -- also verified on-device -- but "kill whatever holds js0" is
-#     dangerous: keymon.elf opens input devices and runs throughout the
-#     game, and killing the launcher is known to power this device off.
-#     A cleanup that can kill the launcher is not worth a leak that clears
-#     itself.
-#
-# And it does clear itself: dd was started with count=1, so the first
-# controller event after flycast starts makes it read one event and exit,
-# hexdump then sees EOF, and the substitution child follows. joydev gives
-# each opener an independent event buffer, so nothing is taken from
-# flycast in the meantime.
-nx_cancel_disarm() {
-    [ -n "$NX_CANCEL_PID" ] && kill "$NX_CANCEL_PID" 2>/dev/null
-    NX_CANCEL_PID=""
-    rm -f "$NX_CANCEL_FLAG"
-    return 0
-}
-
-# Serve $NETPLAY_SRV on 19714 with whatever this firmware provides:
-# busybox httpd (tg5040) or python3 http.server (tg5050, whose busybox
-# 1.35 ships no httpd applet). Neither present -> no server, fail open.
-# httpd runs without -v, so there is no request log at all: $NETPLAY_LOG
-# only ever holds the server's own stdout/stderr (empty on tg5040). It
-# still lives OUTSIDE the serve dir so it is never itself served.
-# Must run in the parent shell, never inside $( ) -- NX_HTTPD_PID has to
-# survive for the cleanup block after wait $EMU_PID.
-nx_serve_start() {
-    # The pidfile is only removed on a clean exit, so a power-off or a
-    # hybrid-sleep leaves a stale one behind and the pid it names may have
-    # been recycled onto an unrelated process by the next launch. Blind
-    # SIGTERM to a recycled pid is a genuinely bad outcome on this device
-    # family, so confirm the pid is actually one of our servers before
-    # signalling it: /proc/<pid>/comm reads "httpd" or "python3" (the
-    # python path execs, so the subshell is replaced and comm is the
-    # interpreter, not sh). The pidfile goes either way -- a pid we
-    # decline to kill is not ours to keep tracking.
-    #
-    # BOTH stages are needed; the digits test alone is not enough. It
-    # accepts "0", and `kill 0` signals EVERY process in our process
-    # group. That is unreachable only because /proc/0/comm does not
-    # exist, so the comm test rejects it -- do not drop that test.
-    if [ -f /tmp/nx_netplay.pid ]; then
-        NXS_OLD=$(cat /tmp/nx_netplay.pid 2>/dev/null)
-        case "$NXS_OLD" in
-            ""|*[!0-9]*) ;;
-            *)
-                # A zero pid passes the all-digits test above, and
-                # `kill 0` signals EVERY process in this script's process
-                # group -- on this device family that reaches the
-                # launcher, and killing the launcher powers the unit off.
-                # /proc/0/comm not existing does block it today, but a
-                # guard against that blast radius should not rest on one
-                # accident. Test arithmetically rather than matching a
-                # literal 0: "00" is also zero and slips past a pattern.
-                if [ "$NXS_OLD" -gt 0 ]; then
-                    case "$(cat "/proc/$NXS_OLD/comm" 2>/dev/null)" in
-                        httpd|python3) kill "$NXS_OLD" 2>/dev/null ;;
-                    esac
-                fi
-                ;;
-        esac
-        rm -f /tmp/nx_netplay.pid
-    fi
-    if command -v httpd >/dev/null 2>&1; then
-        httpd -f -p "$NETPLAY_PORT" -h "$NETPLAY_SRV" > "$NETPLAY_LOG" 2>&1 &
-        NX_HTTPD_PID=$!
-    elif command -v python3 >/dev/null 2>&1; then
-        ( cd "$NETPLAY_SRV" && exec python3 -u -m http.server "$NETPLAY_PORT" ) \
-            > "$NETPLAY_LOG" 2>&1 &
-        NX_HTTPD_PID=$!
-    fi
-    [ -n "$NX_HTTPD_PID" ] && echo "$NX_HTTPD_PID" > /tmp/nx_netplay.pid
-}
-
-# True when $1 serves a netplay-info for this ROM in role $2. The role
-# line is what stops two hosts (or two clients) from pairing, and the
-# ROM line stops cross-game pairing.
-nx_probe() {
-    NXI=$(nx_fetch "http://$1:$NETPLAY_PORT/netplay-info" 3)
-    [ "$(printf '%s\n' "$NXI" | sed -n 1p)" = "$EMU_OVERLAY_GAME" ] && \
-    [ "$(printf '%s\n' "$NXI" | sed -n 2p)" = "$2" ]
-}
-
-# Print the IP of a peer in role $1, or nothing. Tries the stored server=
-# first, but only when it is in our current /24 -- after a relocation the
-# stored address belongs to the old network and can never answer, so
-# probing it just burns ~3s. Then ping-sweeps the /24 and probes every
-# neighbour CONCURRENTLY: serial probes cost >=1s each (nx_fetch's poll
-# floor), so a LAN with N reachable hosts used to cost ~N seconds per
-# pass. Runs inside $( ) -- it must not set anything the caller needs.
-nx_find_peer() {
-    NXP_WANT=$1
-    NXP_MYIP=$(ip -4 addr show wlan0 2>/dev/null | \
-        sed -n 's|.*inet \([0-9.]*\)/24 .*|\1|p' | head -1)
-    NXP_NET=${NXP_MYIP%.*}
-    NXP_STORED=$(nx_cfg_get network server)
-    if [ -n "$NXP_STORED" ] && [ -n "$NXP_NET" ] && \
-       [ "${NXP_STORED%.*}" = "$NXP_NET" ] && \
-       nx_probe "$NXP_STORED" "$NXP_WANT"; then
-        echo "$NXP_STORED"
-        return
-    fi
-    NXP_HITS=/tmp/nx_netplay_hits
-    NXP_END=$(( $(date +%s) + NETPLAY_DEADLINE ))
-    while [ "$(date +%s)" -lt "$NXP_END" ]; do
-        nx_cancelled && return
-        if [ -n "$NXP_NET" ]; then
-            NXP_I=1
-            while [ "$NXP_I" -le 254 ]; do
-                ping -c1 -W1 "$NXP_NET.$NXP_I" >/dev/null 2>&1 &
-                NXP_I=$((NXP_I+1))
-            done
-            sleep 3
-        else
-            # No /24 sweep to pace the loop; without this an empty
-            # neighbour table would spin the deadline loop hot.
-            sleep 1
-        fi
-        rm -rf "$NXP_HITS"
-        mkdir -p "$NXP_HITS"
-        # A /24 sweep leaves an ARP entry for EVERY address it probed, and
-        # a router that answers ARP for unused addresses turns that into
-        # hundreds of entries sharing a handful of MACs. Probing all of
-        # them spawns hundreds of concurrent wgets on a 4-core handheld,
-        # none finish inside the collect window below, and the peer is
-        # never found -- one half of how the first real pair test failed.
-        # The other half is nx_fetch's shared temp file (see there): dedup
-        # ALONE cannot fix discovery, because that race destroys the
-        # result at any concurrency.
-        #
-        # Deduplicate by MAC: one candidate per physical device. Measured
-        # on-device, as one dataset through the two filter stages:
-        #   raw `ip neigh`                     259 lines, ~19 MACs
-        #   after the IPv4 + valid-lladdr sed  222 lines,  16 MACs
-        # so 16 candidates survive, the real peer among them -- phantoms
-        # share the router's MAC, real devices each keep their own.
-        #
-        # awk rather than `sort -u -k1,1` because a busybox built without
-        # CONFIG_FEATURE_SORT_BIG has no `-k` at all; where `-k` exists,
-        # `sort -u` does honour it (verified on tg5050).
-        #
-        # Both sed anchors are load-bearing, and they earn their keep on
-        # different inputs:
-        #   ^\([0-9.]*\)   excludes IPv6, which is checked before the
-        #     lladdr group is even consulted. It matters: an IPv6 neighbour
-        #     sharing the PEER's MAC would otherwise claim that MAC's
-        #     seen[] slot and hide the peer behind an unprobeable candidate.
-        #   \{17\}         excludes malformed lladdr values. Without it
-        #     "192.168.1.20 dev wlan0 lladdr INCOMPLETE" yields an empty
-        #     MAC key and awk then prints an empty candidate.
-        for NXP_IP in $(ip neigh 2>/dev/null | \
-                sed -n 's/^\([0-9.]*\) .*lladdr \([0-9a-f:]\{17\}\).*/\2 \1/p' | \
-                awk '!seen[$1]++ {print $2}'); do
-            nx_cancelled && return
-            [ "$NXP_IP" = "$NXP_MYIP" ] && continue
-            ( nx_probe "$NXP_IP" "$NXP_WANT" && : > "$NXP_HITS/$NXP_IP" ) &
-        done
-        # One probe's worth of wall clock rather than N probes' -- but note
-        # this function runs inside $( ), and a command substitution does
-        # not return until every background child it spawned has exited
-        # (they inherit the capture pipe). So the caller actually waits
-        # max(this sleep, slowest straggler probe). That is bounded: each
-        # nx_probe goes through nx_fetch's 3s watchdog. Measure the
-        # substitution, not this sleep, when timing a pass.
-        sleep 4
-        # Sorted so a re-run on an unchanged LAN picks the same peer.
-        NXP_FOUND=$(ls "$NXP_HITS" 2>/dev/null | sort | head -1)
-        rm -rf "$NXP_HITS"
-        if [ -n "$NXP_FOUND" ]; then
-            echo "$NXP_FOUND"
-            return
-        fi
-    done
-}
-
-nx_netplay_host() {
-    NXH_DATA="$USERDATA_DIR/data/flycast"
-    # Deliberately no progress value. This call and the -1 one below are
-    # both backgrounded and may still be waiting on show2's FIFO during
-    # its ~3-4s init, so their arrival order is not guaranteed. A numeric
-    # PROGRESS: landing after the -1 would cancel the marquee and freeze
-    # the bar for the whole discovery wait. Sending none means the only
-    # progress the daemon can see before that wait is -1, which makes this
-    # path deterministic and matches the client path.
-    nx_ui "Preparing saves..."
-    # One-deep crash insurance: the REAL card is live during a netplay
-    # session, so snapshot it first (~384 KB, overwritten each session).
-    mkdir -p "$USERDATA_DIR/netplay-backup"
-    cp -f "$NXH_DATA"/vmu_save_*.bin "$NXH_DATA/dc_nvmem.bin" \
-        "$USERDATA_DIR/netplay-backup/" 2>/dev/null
-    rm -rf "$NETPLAY_SRV"
-    mkdir -p "$NETPLAY_SRV"
-    printf '%s\nhost\n' "$EMU_OVERLAY_GAME" > "$NETPLAY_SRV/netplay-info"
-    (cd "$NXH_DATA" 2>/dev/null && \
-        tar cf "$NETPLAY_SRV/netplay-sync.tar" vmu_save_*.bin dc_nvmem.bin 2>/dev/null)
-    nx_serve_start
-    nx_cancelled && { NX_CANCELLED=1; return 0; }
-    # Computed here in the parent shell: nx_find_peer's own copy lives in
-    # a $( ) subshell and would always read back empty at this point.
-    NXH_NET=$(ip -4 addr show wlan0 2>/dev/null | \
-        sed -n 's|.*inet \([0-9.]*\)/24 .*|\1|p' | head -1)
-    if [ -n "$NXH_NET" ]; then NXH_WHERE="${NXH_NET%.*}.x"; else NXH_WHERE="the network"; fi
-    nx_ui "Looking for player 2 on $NXH_WHERE..." -1
-    NXH_PEER=$(nx_find_peer client)
-    if [ -n "$NXH_PEER" ]; then
-        nx_cfg_set network server "$NXH_PEER"
-        nx_ui "Player 2 found at $NXH_PEER" 90
-    else
-        nx_ui "No player 2 found - starting anyway" 100
-    fi
-    # No peer found: fail open on whatever server= already holds.
-}
-
-nx_netplay_client() {
-    NXC_NPDATA="$USERDATA_DIR/netplay-data/flycast"
-    mkdir -p "$NXC_NPDATA"
-    nx_ui "Looking for the host..." -1
-    # The client serves only its identity -- never any save data.
-    rm -rf "$NETPLAY_SRV"
-    mkdir -p "$NETPLAY_SRV"
-    printf '%s\nclient\n' "$EMU_OVERLAY_GAME" > "$NETPLAY_SRV/netplay-info"
-    nx_serve_start
-    nx_cancelled && { NX_CANCELLED=1; return 0; }
-    NXC_PEER=$(nx_find_peer host)
-    if [ -n "$NXC_PEER" ]; then
-        nx_cfg_set network server "$NXC_PEER"
-        nx_ui "Host found at $NXC_PEER - copying saves..." 60
-        nx_fetch "http://$NXC_PEER:$NETPLAY_PORT/netplay-sync.tar" 30 > /tmp/nx_netplay_sync.tar
-        # Tar-slip guard: the peer is discovered, not authenticated, and
-        # this script runs as root, so accept an archive only when ALL of
-        # these hold -- it lists at least one entry (a non-tar payload
-        # lists nothing, which would pass every negated test vacuously);
-        # every name is a bare expected filename (no slashes, no "..",
-        # no absolute paths); every mode column is "-"; and no entry is a
-        # link. The explicit link test is NOT redundant with the mode
-        # column: busybox tar prints a HARDLINK as "-" (only GNU tar uses
-        # "h"), so on this firmware the mode column alone would accept
-        # one. Both link kinds render their target as "name -> target".
-        # Without this a link named vmu_save_A1.bin could land in
-        # netplay-data and flycast would write VMU data through it.
-        if [ -s /tmp/nx_netplay_sync.tar ] && \
-           tar tf /tmp/nx_netplay_sync.tar 2>/dev/null | grep -q . && \
-           ! tar tf /tmp/nx_netplay_sync.tar 2>/dev/null | \
-             grep -qv '^vmu_save_[A-D][12]\.bin$\|^dc_nvmem\.bin$' && \
-           ! tar tvf /tmp/nx_netplay_sync.tar 2>/dev/null | \
-             grep -qv '^-' && \
-           ! tar tvf /tmp/nx_netplay_sync.tar 2>/dev/null | \
-             grep -q ' -> '; then
-            (cd "$NXC_NPDATA" && tar xf /tmp/nx_netplay_sync.tar 2>/dev/null)
-        fi
-        rm -f /tmp/nx_netplay_sync.tar
-    fi
-    [ -n "$NXC_PEER" ] || nx_ui "No host found - starting anyway" 100
-    # Borrowed-copy isolation: play on the synced copy; the client's real
-    # saves under data/flycast are never read or written during netplay.
-    #
-    # Cancelled means "play this game normally", so do NOT redirect saves
-    # to the borrowed netplay-data copy -- with GGPO off there is nothing
-    # to isolate, and the user would otherwise be playing single-player on
-    # the host's VMU instead of their own. (Their real saves are untouched
-    # either way; this is about which set the session actually uses.)
-    if nx_cancelled; then
-        NX_CANCELLED=1
-    else
+        # client plays on the borrowed copy; its own saves are untouched
+        mkdir -p "$USERDATA_DIR/netplay-data/flycast"
         export XDG_DATA_HOME="$USERDATA_DIR/netplay-data"
+        NX_AS_SERVER=no
     fi
-}
-
-if [ "$(nx_cfg_get network GGPO)" = "yes" ]; then
-    nx_ui_start "Starting..." "B = skip netplay"
-    nx_cancel_arm
-    # Plug a controller into DC port B. GGPO always drives port B as
-    # player 2 -- the REMOTE player on the host, the LOCAL player on the
-    # client (ggpo.cpp:500,569 make the local player localPlayerNum + 1;
-    # ggpo.cpp:643-650 writes inputState[player] straight to the maple
-    # port index) -- so BOTH machines need a pad there; that the client's
-    # own Start did nothing is exactly this. flycast leaves device2 =
-    # MDT_None (10) by default (option.cpp:197-201), so with port B empty
-    # those inputs reach no maple device and MvC2's VS mode stays greyed
-    # out. Both peers must carry the identical value or the emulated
-    # machines differ and desync -- which is why this is set here on both
-    # sides, not by hand.
-    nx_cfg_set input device2 0
-    # Close flycast's router port punching. EnableUPnP defaults to TRUE
-    # (option.cpp:172), and ggpo.cpp:801-804 runs miniupnp.Init() +
-    # AddPortMapping(19713/UDP) BEFORE the ActAsServer branch, so BOTH
-    # roles punch a mapping with an 86400 s lease (miniupnp.cpp). The
-    # seeded EnableUPnP = no in the default*.cfg files only reaches FRESH
-    # installs (it is gated behind .initialized), so no existing device
-    # ever gets it -- setting it here closes it everywhere. No
-    # restore-when-off branch is needed: the value is only consulted on
-    # the GGPO path.
-    nx_cfg_set network EnableUPnP no
-    if [ "$(nx_cfg_get network ActAsServer)" = "yes" ]; then
-        nx_netplay_host
-    else
-        nx_netplay_client
-    fi
-    if nx_cancelled; then
-        NX_CANCELLED=1
-        # nx_serve_start has already run in both role functions by the
-        # time a cancel is noticed, and on the host path the tar holds
-        # real VMU + dc_nvmem data. Without this the server keeps
-        # offering it on TCP 19714 until `wait $EMU_PID` returns -- i.e.
-        # for the whole session the user asked to spend NOT doing
-        # netplay. Tear it down here rather than in each role function.
-        if [ -n "$NX_HTTPD_PID" ]; then
-            kill "$NX_HTTPD_PID" 2>/dev/null
-            NX_HTTPD_PID=""
-        fi
-        rm -f /tmp/nx_netplay.pid
-        rm -rf "$NETPLAY_SRV"
-        nx_ui "Skipped - starting game..."
-        # nx_ui only QUEUES its write in a background subshell, and
-        # nx_ui_stop kills show2 immediately below, so without this pause
-        # the confirmation is never drawn -- pressing B would look exactly
-        # like nothing happening until flycast appears. One second is
-        # enough for the subshell to be scheduled, open the FIFO and for
-        # show2 to render a frame (it runs at 60 fps). This cost is paid
-        # ONLY on the cancel path, never on a normal launch.
-        sleep 1
-    fi
-    # Disarming deletes the flag file, so it MUST stay after the test
-    # above -- do not reorder these two.
-    nx_cancel_disarm
-    nx_ui_stop
-else
-    # Netplay off: unplug port B again so single-player sessions see the
-    # stock one-pad Dreamcast. It rewrites the key only when it currently
-    # holds this block's own value (0), so a user who deliberately
-    # configured another port-B device is not clobbered -- but a 0 set
-    # through flycast's own Controls UI for local two-pad play is
-    # indistinguishable from ours and does get reverted here.
-    [ "$(nx_cfg_get input device2)" = "0" ] && nx_cfg_set input device2 10
+    # device2=0 plugs a pad into DC port B on BOTH sides (GGPO drives
+    # port B as player 2 -- remote on the host, LOCAL on the client);
+    # EnableUPnP=no stops ggpo.cpp:801-804 punching a router mapping.
+    NETPLAY_ARGS="-config network:GGPO=yes -config network:ActAsServer=$NX_AS_SERVER -config network:server=$NETPLAY_PEER_IP -config network:EnableUPnP=no -config input:device2=0"
 fi
 # --- end netplay -------------------------------------------------------
 
 cd "$PAK_DIR"
-if [ -n "$NX_CANCELLED" ]; then
-    # Virtual config: flycast's get_entry() prefers virtual values and
-    # ConfigFile::save() never writes them, so this disables netplay for
-    # THIS RUN ONLY and emu.cfg is left byte-identical.
-    ./flycast -config network:GGPO=no "$ROM" &> "$LOGS_PATH/$EMU_TAG.txt" &
-else
-    ./flycast "$ROM" &> "$LOGS_PATH/$EMU_TAG.txt" &
-fi
+# $NETPLAY_ARGS is deliberately UNQUOTED: it is a word-split argument list
+# (-config pairs) whose values contain no whitespace, and it is empty on
+# every normal launch, where it word-splits to nothing at all.
+./flycast $NETPLAY_ARGS "$ROM" &> "$LOGS_PATH/$EMU_TAG.txt" &
 EMU_PID=$!
 
 # Thread pinning (cpu0-3 are all Cortex-A53 @ 2000 MHz). Evidence-based (see
@@ -779,8 +294,9 @@ kill -0 "$EMU_PID" 2>/dev/null && pin_threads
 wait $EMU_PID
 killall sleepmon.elf 2>/dev/null || true
 kill $SYNC_PID 2>/dev/null || true
-if [ -n "$NX_HTTPD_PID" ]; then
-    kill "$NX_HTTPD_PID" 2>/dev/null
-    rm -f /tmp/nx_netplay.pid
-fi
+# Netplay teardown: the session file is the only marker that this run went
+# through the wizard, so its presence gates the whole thing. --cleanup stops
+# the host's rsyncd, tears down a hotspot AP, restores the previous WiFi
+# network, and removes /tmp/netplay_session. Harmless on a plain launch.
+[ -f /tmp/netplay_session ] && netplay.elf --cleanup >> "$LOGS_PATH/netplay-wizard.txt" 2>&1
 echo 0 > /sys/class/speaker/mute 2>/dev/null || true

--- a/skeleton/EXTRAS/Emus/tg5040/DC.pak/launch.sh
+++ b/skeleton/EXTRAS/Emus/tg5040/DC.pak/launch.sh
@@ -14,26 +14,8 @@ echo performance >/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
 echo 2000000 >/sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq
 echo 1608000 >/sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq
 
-# User data (config per device, VMU + save states shared across devices)
-USERDATA_DIR="$SHARED_USERDATA_PATH/DC-flycast"
-if [ "$DEVICE" = "brick" ]; then
-    DEVICE_CONFIG_DIR="$USERDATA_DIR/config/tg5040-brick"
-    DEVICE_DEFAULT_CFG="$PAK_DIR/default-brick.cfg"
-elif [ "$DEVICE" = "brickpro" ]; then
-    DEVICE_CONFIG_DIR="$USERDATA_DIR/config/tg5040-brickpro"
-    DEVICE_DEFAULT_CFG="$PAK_DIR/default-brickpro.cfg"
-else
-    DEVICE_CONFIG_DIR="$USERDATA_DIR/config/tg5040-smart-pro"
-    DEVICE_DEFAULT_CFG="$PAK_DIR/default-smartpro.cfg"
-fi
-mkdir -p "$DEVICE_CONFIG_DIR/flycast/mappings" "$USERDATA_DIR/data/flycast"
-
-# First run: copy device-specific defaults
-if [ ! -f "$DEVICE_CONFIG_DIR/.initialized" ]; then
-    cp "$DEVICE_DEFAULT_CFG" "$DEVICE_CONFIG_DIR/flycast/emu.cfg"
-    touch "$DEVICE_CONFIG_DIR/.initialized"
-fi
-EMU_CFG="$DEVICE_CONFIG_DIR/flycast/emu.cfg"
+# Config-dir resolution + emu.cfg seeding shared with options.sh
+. "$PAK_DIR/nx_paths.sh"
 
 # Install the curated controller mapping if not already present. Deliberately
 # NOT gated by .initialized: that marker only tracks the emu.cfg seed, so an
@@ -82,6 +64,7 @@ MINUI_DIR="$SHARED_USERDATA_PATH/.minui/$EMU_TAG"
 mkdir -p "$MINUI_DIR"
 export EMU_OVERLAY_SCREENSHOT_DIR="$MINUI_DIR"
 export EMU_OVERLAY_ROMFILE="$(basename "$ROM")"
+export EMU_OVERLAY_HIDE_OPTIONS=1  # options moved to the pre-launch editor (options.sh)
 
 # Mute speaker before launch to prevent audio pop, then unmute after init
 echo 1 > /sys/class/speaker/mute 2>/dev/null || true
@@ -121,8 +104,10 @@ export NX_AUDIO_RATE=$(nx_pick_audio_rate 44100)
 # VMU/flash read-only on TCP 18731; the client pulls into netplay-data).
 # Every netplay value below is passed as a VIRTUAL -config: flycast's
 # get_entry() prefers virtual values and ConfigFile::save() never writes
-# them, so emu.cfg is untouched by a netplay run. GGPODelay/DCNet remain
-# real overlay settings that flycast reads from emu.cfg itself.
+# them, so emu.cfg is untouched by a netplay run. GGPODelay remains a
+# real overlay setting that flycast reads from emu.cfg itself; DCNet is
+# forced off among the virtual values below, so its overlay/per-game
+# value only ever reaches a normal launch.
 # Design: docs/superpowers/specs/2026-07-29-netplay-prelaunch-wizard-design.md
 
 # Read one key from one section of emu.cfg (empty when absent).
@@ -209,15 +194,43 @@ if [ -f /tmp/netplay_launch ]; then
     # device2=0 plugs a pad into DC port B on BOTH sides (GGPO drives
     # port B as player 2 -- remote on the host, LOCAL on the client);
     # EnableUPnP=no stops ggpo.cpp:801-804 punching a router mapping.
-    NETPLAY_ARGS="-config network:GGPO=yes -config network:ActAsServer=$NX_AS_SERVER -config network:server=$NETPLAY_PEER_IP -config network:EnableUPnP=no -config input:device2=0"
+    # DCNet=no is forced: DCNet routes the emulated modem to an external
+    # cloud service, an input the GGPO lockstep never synchronizes, so a
+    # peer's modem traffic desyncs the session. A per-game or global
+    # DCNet=yes IS a repeated key here and NETPLAY_ARGS comes last, so it
+    # loses on a netplay launch and still applies to a normal one.
+    NETPLAY_ARGS="-config network:GGPO=yes -config network:ActAsServer=$NX_AS_SERVER -config network:server=$NETPLAY_PEER_IP -config network:EnableUPnP=no -config input:device2=0 -config network:DCNet=no"
 fi
 # --- end netplay -------------------------------------------------------
 
+# --- Per-game option overrides ------------------------------------------
+# Written by options.elf ("Emulator Options" in the game list's context
+# menu). Each entry becomes a VIRTUAL -config (never persisted by flycast),
+# so emu.cfg stays the device-global config and flycast's wholesale config
+# rewriting can never bake per-game values into it. Values are ints/bools
+# and never contain whitespace, so word-splitting GAME_ARGS is safe.
+# A malformed or unreadable file yields no args: the game still launches.
+GAME_ARGS=""
+NX_ROM_BASE="$(nx_rom_base "$ROM")"
+NX_GAME_CFG="$DEVICE_CONFIG_DIR/games/$NX_ROM_BASE.cfg"
+if [ -f "$NX_GAME_CFG" ]; then
+    GAME_ARGS=$(awk -F' = ' '
+        /^\[.*\]$/ { sec = substr($0, 2, length($0) - 2); next }
+        NF == 2 && sec != "" { printf "-config %s:%s=%s ", sec, $1, $2 }
+    ' "$NX_GAME_CFG" 2>/dev/null)
+fi
+# --- end per-game overrides ---------------------------------------------
+
 cd "$PAK_DIR"
-# $NETPLAY_ARGS is deliberately UNQUOTED: it is a word-split argument list
-# (-config pairs) whose values contain no whitespace, and it is empty on
-# every normal launch, where it word-splits to nothing at all.
-./flycast $NETPLAY_ARGS "$ROM" &> "$LOGS_PATH/$EMU_TAG.txt" &
+# $GAME_ARGS / $NETPLAY_ARGS are deliberately UNQUOTED: word-split argument
+# lists (-config pairs) whose values contain no whitespace, empty on normal
+# launches. NETPLAY_ARGS comes last so its network:* values win over any
+# per-game override on a netplay launch: flycast's LAST -config wins for a
+# repeated section:key -- ParseCommandLine() walks argv left-to-right
+# (core/cfg/cl.cpp) and every -config lands in cfgSetVirtual() ->
+# ConfigSection::set(), a plain std::map assignment that overwrites
+# (core/cfg/ini.cpp).
+./flycast $GAME_ARGS $NETPLAY_ARGS "$ROM" &> "$LOGS_PATH/$EMU_TAG.txt" &
 EMU_PID=$!
 
 # Thread pinning (cpu0-3 are all Cortex-A53 @ 2000 MHz). Evidence-based (see

--- a/skeleton/EXTRAS/Emus/tg5040/DC.pak/launch.sh
+++ b/skeleton/EXTRAS/Emus/tg5040/DC.pak/launch.sh
@@ -114,8 +114,595 @@ nx_pick_audio_rate() {
 # Dreamcast AICA is natively 44.1 kHz
 export NX_AUDIO_RATE=$(nx_pick_audio_rate 44100)
 
+# --- Netplay auto-sync + auto-discovery (GGPO) -------------------------
+# Runs only when [network] GGPO = yes in emu.cfg (the overlay's Netplay
+# section). BOTH devices serve a role-tagged netplay-info on TCP 19714
+# and BOTH scan the LAN for a peer running the same ROM in the OPPOSITE
+# role, because GGPO is peer-to-peer: each side must know the other's
+# address (ggpo.cpp:579-597 -- an empty server= makes flycast target
+# loopback on localPort ^ 1: 19712 from the host, 19713 from the client,
+# then wait forever on "Starting Network", which has no timeout, only a
+# Cancel button). v1 had the host learn the client's IP
+# passively from its own access log inside a pre-launch window; a client
+# that was late, absent, or launched first left the host hung. Scanning
+# on both sides makes launch order and timing irrelevant.
+#   host   - plays on its REAL VMU/flash and also serves a tar of exactly
+#            the GGPO-hashed files (vmu_save_*.bin + dc_nvmem.bin, see
+#            ggpo.cpp:537), so whoever hosts contributes their own saves
+#   client - pulls that tar into an isolated netplay-data dir and plays
+#            on the borrowed copy; its own saves are never touched
+# Every failure path falls through to a normal launch ("fail-open").
+# Design: docs/superpowers/specs/2026-07-28-netplay-state-sync-design.md
+NETPLAY_PORT=19714
+NETPLAY_SRV=/tmp/nx_netplay
+NETPLAY_LOG=/tmp/nx_netplay.log
+NETPLAY_DEADLINE=90
+NX_HTTPD_PID=""
+
+# Read one key from one section of emu.cfg (empty when absent).
+nx_cfg_get() {
+    sed -n "/^\[$1\]/,/^\[/s/^$2 = *//p" "$EMU_CFG" | head -1
+}
+
+# Set one key in one section of emu.cfg, creating the section and/or the
+# key when missing. flycast drops keys left at their default when it
+# rewrites the file on quit, so [input] and server= are routinely absent
+# from a live cfg -- never assume either exists.
+nx_cfg_set() {
+    grep -q "^\[$1\]$" "$EMU_CFG" || printf '\n[%s]\n' "$1" >> "$EMU_CFG"
+    sed -n "/^\[$1\]/,/^\[/p" "$EMU_CFG" | grep -q "^$2 =" || \
+        sed -i "s/^\[$1\]\$/[$1]\n$2 =/" "$EMU_CFG"
+    sed -i "/^\[$1\]/,/^\[/s|^$2 =.*|$2 = $3|" "$EMU_CFG"
+}
+
+# wget with a watchdog: busybox wget has no timeout flag, so kill it
+# ourselves after $2 seconds. Prints fetched content (empty on failure).
+nx_fetch() {
+    # Each discovery pass runs a dozen-plus nx_fetch calls CONCURRENTLY,
+    # and in POSIX sh `$$` keeps the PARENT shell's pid inside a subshell
+    # -- so a pid-derived name is the SAME file in every probe. Measured
+    # on-device: 16 concurrent probes against a network with exactly one
+    # real peer returned ZERO hits, because one probe's trailing `rm -f`
+    # deleted the payload another had just downloaded; the same race also
+    # made a dead host report a live host's payload and win the `ls |
+    # sort | head -1` selection. Both present as "stuck looking for
+    # player 2", and this is the other half of the first pair test's
+    # failure: fixing it ALONE would still have been swamped by the ~250
+    # concurrent probes the un-deduplicated neighbour list produced (see
+    # nx_find_peer). Both fixes are required.
+    #
+    # The name must be unique per invocation. mktemp is at
+    # /bin/mktemp on both devices; the fallback derives uniqueness from
+    # the URL, which is likewise distinct for every concurrent probe.
+    NXF_OUT=$(mktemp /tmp/nx_netplay_fetch.XXXXXX 2>/dev/null)
+    if [ -z "$NXF_OUT" ]; then
+        NXF_OUT=/tmp/nx_netplay_fetch.$(printf '%s' "$1" | tr -c 'a-zA-Z0-9' '_')
+        rm -f "$NXF_OUT"
+    fi
+    wget -q -O "$NXF_OUT" "$1" 2>/dev/null &
+    NXF_PID=$!
+    NXF_T=0
+    while [ "$NXF_T" -lt "$2" ]; do
+        kill -0 "$NXF_PID" 2>/dev/null || break
+        # Abort promptly on cancel: without this a press during the
+        # client's up-to-30s tar download would sit unnoticed until the
+        # download finished. Callers already treat an empty result as a
+        # failed fetch.
+        nx_cancelled && break
+        sleep 1
+        NXF_T=$((NXF_T+1))
+    done
+    kill "$NXF_PID" 2>/dev/null
+    wait "$NXF_PID" 2>/dev/null
+    cat "$NXF_OUT" 2>/dev/null
+    rm -f "$NXF_OUT"
+}
+
+# --- status display -----------------------------------------------------
+# Drives show2.elf (already shipped in $SYSTEM_PATH/bin) in daemon mode so
+# the long discovery phase is not a silent black screen. show2 renders via
+# SDL2/DRM -- /dev/fb0 is NOT the display path on these devices, so a
+# framebuffer-writing helper would draw nothing. Every call here is a
+# guarded no-op when show2.elf is missing or its daemon died: discovery and
+# launch must never block or fail because of the UI.
+NX_UI_FIFO=/tmp/show2.fifo
+NX_UI_ON=""
+
+NX_CANCEL_FLAG=/tmp/nx_netplay_cancel
+NX_CANCEL_BTN=00          # physical B. Measured on a Brick 2026-07-29:
+                          # five presses, all "01 00 01 00" (value 0001,
+                          # type 01, number 00). Agrees with this pak's own
+                          # SDL_Xbox 360 Controller.cfg (bind0 = 0:btn_b).
+NX_CANCEL_PID=""
+NX_CANCELLED=""
+
+nx_ui_start() {
+    # Resolved via PATH ($SYSTEM_PATH/bin), exactly like this script's own
+    # bare sleepmon.elf / syncsettings.elf / taskset calls. Do NOT build a
+    # $SDCARD_PATH/.system/<platform>/bin path here: that differs per device
+    # and this block must stay byte-identical across both launch.sh files.
+    command -v show2.elf >/dev/null 2>&1 || return 0
+    rm -f "$NX_UI_FIFO"
+    # show2 needs libSDL2 from $SDCARD_PATH/.system/<platform>/lib, which
+    # launch.sh already put on LD_LIBRARY_PATH above; without it show2
+    # aborts with "libSDL2-2.0.so.0: cannot open shared object file".
+    # --image is mandatory but we have no netplay artwork; /dev/null is the
+    # repo's existing "no logo" idiom (see PortMaster's progressor).
+    # --progress=-1 selects show2's indeterminate marquee (show2.cpp:424),
+    # which is what the install boot.sh uses for exactly this kind of
+    # unknown-length wait -- an empty 0% bar would just look stalled.
+    if [ -n "$2" ]; then
+        show2.elf --mode=daemon --image=/dev/null --bgcolor=0x000000 \
+            --progress=-1 --text="$1" --hint="$2" >/dev/null 2>&1 &
+    else
+        show2.elf --mode=daemon --image=/dev/null --bgcolor=0x000000 \
+            --progress=-1 --text="$1" >/dev/null 2>&1 &
+    fi
+    NX_UI_ON=$!
+    # Daemon needs ~3-4s (SDL2 + DRM init) before it paints; do not wait
+    # for it here -- the network work below overlaps that cost.
+}
+
+# nx_ui "<message>" [progress 0-100]
+# Opening a FIFO for writing BLOCKS until a reader attaches, so a daemon
+# that died while leaving its FIFO node behind would hang the launch
+# forever on the next status update -- the exact failure this feature
+# exists to prevent. Two defences: skip when the daemon PID is gone, and
+# do the write in a background subshell so even a lost race can only
+# strand that subshell, never the script.
+nx_ui() {
+    [ -n "$NX_UI_ON" ] || return 0
+    kill -0 "$NX_UI_ON" 2>/dev/null || return 0
+    # show2 creates the FIFO only after its SDL2/DRM init: mkfifo is the
+    # first statement of runDaemonMode(), which runs after initialize()
+    # returns (~3-4s). A plain [ -p ] test here would therefore DROP every
+    # early message -- and those are the ones that matter, because the next
+    # update can be up to NETPLAY_DEADLINE seconds later. So wait for the
+    # node, but do it INSIDE the background subshell so the script itself
+    # never stalls. Ordering between messages queued during that init
+    # window is not guaranteed; they all land within a second of each
+    # other and only the last is visible, which is acceptable here.
+    ( NXU_T=0
+      while [ ! -p "$NX_UI_FIFO" ] && [ "$NXU_T" -lt 10 ]; do
+          kill -0 "$NX_UI_ON" 2>/dev/null || exit 0
+          sleep 1
+          NXU_T=$((NXU_T+1))
+      done
+      [ -p "$NX_UI_FIFO" ] || exit 0
+      printf 'TEXT:%s\n' "$1" > "$NX_UI_FIFO" 2>/dev/null
+      [ -n "$2" ] && printf 'PROGRESS:%s\n' "$2" > "$NX_UI_FIFO" 2>/dev/null
+      : ) &
+    return 0
+}
+
+nx_ui_stop() {
+    [ -n "$NX_UI_ON" ] || return 0
+    # Same blocking hazard as nx_ui, and worse here: this is the LAST
+    # statement before flycast launches, so a dead daemon that left its
+    # FIFO node behind would hang the launch at the finish line. Guard on
+    # liveness and background the write. killall is the real cleanup --
+    # it cannot block -- and the QUIT is only the graceful path.
+    if kill -0 "$NX_UI_ON" 2>/dev/null && [ -p "$NX_UI_FIFO" ]; then
+        ( printf 'QUIT\n' > "$NX_UI_FIFO" 2>/dev/null ) &
+    fi
+    # Belt-and-braces: nothing may hold the display against flycast.
+    # MUST be -9. Measured on a Brick 2026-07-29: after a plain SIGTERM the
+    # daemon was still alive 6 s later; SIGKILL ended it instantly. show2
+    # installs a handler for SIGINT only (show2.cpp:623) and SDL_Init traps
+    # SIGTERM into an SDL_QUIT event that show2 never pumps (it has no
+    # SDL_PollEvent at all), so SIGTERM is swallowed. MinUI.pak's own
+    # launch.sh:228 has always used -9 on this same binary.
+    killall -9 show2.elf 2>/dev/null
+    # Leave no stale node for the next launch to trip over.
+    rm -f "$NX_UI_FIFO" 2>/dev/null
+    NX_UI_ON=""
+    return 0
+}
+
+# --- cancel (press B to skip netplay) ----------------------------------
+# True once the user has asked to skip netplay.
+nx_cancelled() { [ -f "$NX_CANCEL_FLAG" ]; }
+
+# Watch the gamepad for a B press and drop a flag file.
+#
+# js0 delivers 8-byte events: u32 time, s16 value, u8 type, u8 number. A
+# real press is type 01 with a non-zero value; opening the device emits an
+# init burst (type 81/82, value 0) and releases carry value 0, so neither
+# can trigger a cancel, and stick movement (type 02) cannot either.
+#
+# Two shapes were tried on-device and BOTH failed; do not "simplify" back
+# to either:
+#   dd if=js0 | hexdump | while read   -- hexdump BLOCK-BUFFERS to a pipe,
+#     so presses sit unseen until ~4KB (~170 events) accumulates. A 45s
+#     capture recorded zero presses while buttons were being pressed.
+#   dd if=js0 count=1 inside a loop    -- re-opens the device every pass,
+#     replaying the init burst each time, and spins.
+# What works: open ONCE on fd 3, then one short-lived dd/hexdump per event
+# so hexdump exits (and therefore flushes) every time. Verified: presses
+# appear immediately and the loop blocks without spinning when idle.
+#
+# od is not on this firmware; hexdump is. Backgrounded so it can never
+# delay the launch. If js0 is unreadable the subshell exits at once and
+# cancel is simply unavailable -- every other path is unchanged.
+nx_cancel_arm() {
+    rm -f "$NX_CANCEL_FLAG"
+    [ -r /dev/input/js0 ] || return 0
+    (
+        exec 3< /dev/input/js0 || exit 0
+        while :; do
+            NXB_EV=$(dd bs=8 count=1 <&3 2>/dev/null | hexdump -v -e '8/1 "%02x " "\n"')
+            [ -n "$NXB_EV" ] || exit 0
+            set -- $NXB_EV
+            [ "$7" = "01" ] || continue
+            [ "$8" = "$NX_CANCEL_BTN" ] || continue
+            [ "$5$6" = "0000" ] && continue
+            : > "$NX_CANCEL_FLAG"
+            exit 0
+        done
+    ) &
+    NX_CANCEL_PID=$!
+    return 0
+}
+
+# Stop watching.
+#
+# Killing the subshell does NOT reap its children: the blocked dd, the
+# command-substitution child and hexdump each keep js0 open. That leak is
+# deliberately accepted rather than swept, and the reasoning is worth
+# keeping because both obvious sweeps are wrong here:
+#
+#   - Matching /proc/<pid>/cmdline cannot work. The device is opened with
+#     `exec 3< /dev/input/js0` and read with `dd bs=8 count=1 <&3`, so the
+#     path is a redirection, never an argument -- busybox ps shows the dd
+#     as "dd bs 8 count 1". Verified on-device: an argv sweep finds none of
+#     the holders.
+#   - Matching open descriptors (readlink /proc/<pid>/fd/*) DOES find them
+#     all -- also verified on-device -- but "kill whatever holds js0" is
+#     dangerous: keymon.elf opens input devices and runs throughout the
+#     game, and killing the launcher is known to power this device off.
+#     A cleanup that can kill the launcher is not worth a leak that clears
+#     itself.
+#
+# And it does clear itself: dd was started with count=1, so the first
+# controller event after flycast starts makes it read one event and exit,
+# hexdump then sees EOF, and the substitution child follows. joydev gives
+# each opener an independent event buffer, so nothing is taken from
+# flycast in the meantime.
+nx_cancel_disarm() {
+    [ -n "$NX_CANCEL_PID" ] && kill "$NX_CANCEL_PID" 2>/dev/null
+    NX_CANCEL_PID=""
+    rm -f "$NX_CANCEL_FLAG"
+    return 0
+}
+
+# Serve $NETPLAY_SRV on 19714 with whatever this firmware provides:
+# busybox httpd (tg5040) or python3 http.server (tg5050, whose busybox
+# 1.35 ships no httpd applet). Neither present -> no server, fail open.
+# httpd runs without -v, so there is no request log at all: $NETPLAY_LOG
+# only ever holds the server's own stdout/stderr (empty on tg5040). It
+# still lives OUTSIDE the serve dir so it is never itself served.
+# Must run in the parent shell, never inside $( ) -- NX_HTTPD_PID has to
+# survive for the cleanup block after wait $EMU_PID.
+nx_serve_start() {
+    # The pidfile is only removed on a clean exit, so a power-off or a
+    # hybrid-sleep leaves a stale one behind and the pid it names may have
+    # been recycled onto an unrelated process by the next launch. Blind
+    # SIGTERM to a recycled pid is a genuinely bad outcome on this device
+    # family, so confirm the pid is actually one of our servers before
+    # signalling it: /proc/<pid>/comm reads "httpd" or "python3" (the
+    # python path execs, so the subshell is replaced and comm is the
+    # interpreter, not sh). The pidfile goes either way -- a pid we
+    # decline to kill is not ours to keep tracking.
+    #
+    # BOTH stages are needed; the digits test alone is not enough. It
+    # accepts "0", and `kill 0` signals EVERY process in our process
+    # group. That is unreachable only because /proc/0/comm does not
+    # exist, so the comm test rejects it -- do not drop that test.
+    if [ -f /tmp/nx_netplay.pid ]; then
+        NXS_OLD=$(cat /tmp/nx_netplay.pid 2>/dev/null)
+        case "$NXS_OLD" in
+            ""|*[!0-9]*) ;;
+            *)
+                # A zero pid passes the all-digits test above, and
+                # `kill 0` signals EVERY process in this script's process
+                # group -- on this device family that reaches the
+                # launcher, and killing the launcher powers the unit off.
+                # /proc/0/comm not existing does block it today, but a
+                # guard against that blast radius should not rest on one
+                # accident. Test arithmetically rather than matching a
+                # literal 0: "00" is also zero and slips past a pattern.
+                if [ "$NXS_OLD" -gt 0 ]; then
+                    case "$(cat "/proc/$NXS_OLD/comm" 2>/dev/null)" in
+                        httpd|python3) kill "$NXS_OLD" 2>/dev/null ;;
+                    esac
+                fi
+                ;;
+        esac
+        rm -f /tmp/nx_netplay.pid
+    fi
+    if command -v httpd >/dev/null 2>&1; then
+        httpd -f -p "$NETPLAY_PORT" -h "$NETPLAY_SRV" > "$NETPLAY_LOG" 2>&1 &
+        NX_HTTPD_PID=$!
+    elif command -v python3 >/dev/null 2>&1; then
+        ( cd "$NETPLAY_SRV" && exec python3 -u -m http.server "$NETPLAY_PORT" ) \
+            > "$NETPLAY_LOG" 2>&1 &
+        NX_HTTPD_PID=$!
+    fi
+    [ -n "$NX_HTTPD_PID" ] && echo "$NX_HTTPD_PID" > /tmp/nx_netplay.pid
+}
+
+# True when $1 serves a netplay-info for this ROM in role $2. The role
+# line is what stops two hosts (or two clients) from pairing, and the
+# ROM line stops cross-game pairing.
+nx_probe() {
+    NXI=$(nx_fetch "http://$1:$NETPLAY_PORT/netplay-info" 3)
+    [ "$(printf '%s\n' "$NXI" | sed -n 1p)" = "$EMU_OVERLAY_GAME" ] && \
+    [ "$(printf '%s\n' "$NXI" | sed -n 2p)" = "$2" ]
+}
+
+# Print the IP of a peer in role $1, or nothing. Tries the stored server=
+# first, but only when it is in our current /24 -- after a relocation the
+# stored address belongs to the old network and can never answer, so
+# probing it just burns ~3s. Then ping-sweeps the /24 and probes every
+# neighbour CONCURRENTLY: serial probes cost >=1s each (nx_fetch's poll
+# floor), so a LAN with N reachable hosts used to cost ~N seconds per
+# pass. Runs inside $( ) -- it must not set anything the caller needs.
+nx_find_peer() {
+    NXP_WANT=$1
+    NXP_MYIP=$(ip -4 addr show wlan0 2>/dev/null | \
+        sed -n 's|.*inet \([0-9.]*\)/24 .*|\1|p' | head -1)
+    NXP_NET=${NXP_MYIP%.*}
+    NXP_STORED=$(nx_cfg_get network server)
+    if [ -n "$NXP_STORED" ] && [ -n "$NXP_NET" ] && \
+       [ "${NXP_STORED%.*}" = "$NXP_NET" ] && \
+       nx_probe "$NXP_STORED" "$NXP_WANT"; then
+        echo "$NXP_STORED"
+        return
+    fi
+    NXP_HITS=/tmp/nx_netplay_hits
+    NXP_END=$(( $(date +%s) + NETPLAY_DEADLINE ))
+    while [ "$(date +%s)" -lt "$NXP_END" ]; do
+        nx_cancelled && return
+        if [ -n "$NXP_NET" ]; then
+            NXP_I=1
+            while [ "$NXP_I" -le 254 ]; do
+                ping -c1 -W1 "$NXP_NET.$NXP_I" >/dev/null 2>&1 &
+                NXP_I=$((NXP_I+1))
+            done
+            sleep 3
+        else
+            # No /24 sweep to pace the loop; without this an empty
+            # neighbour table would spin the deadline loop hot.
+            sleep 1
+        fi
+        rm -rf "$NXP_HITS"
+        mkdir -p "$NXP_HITS"
+        # A /24 sweep leaves an ARP entry for EVERY address it probed, and
+        # a router that answers ARP for unused addresses turns that into
+        # hundreds of entries sharing a handful of MACs. Probing all of
+        # them spawns hundreds of concurrent wgets on a 4-core handheld,
+        # none finish inside the collect window below, and the peer is
+        # never found -- one half of how the first real pair test failed.
+        # The other half is nx_fetch's shared temp file (see there): dedup
+        # ALONE cannot fix discovery, because that race destroys the
+        # result at any concurrency.
+        #
+        # Deduplicate by MAC: one candidate per physical device. Measured
+        # on-device, as one dataset through the two filter stages:
+        #   raw `ip neigh`                     259 lines, ~19 MACs
+        #   after the IPv4 + valid-lladdr sed  222 lines,  16 MACs
+        # so 16 candidates survive, the real peer among them -- phantoms
+        # share the router's MAC, real devices each keep their own.
+        #
+        # awk rather than `sort -u -k1,1` because a busybox built without
+        # CONFIG_FEATURE_SORT_BIG has no `-k` at all; where `-k` exists,
+        # `sort -u` does honour it (verified on tg5050).
+        #
+        # Both sed anchors are load-bearing, and they earn their keep on
+        # different inputs:
+        #   ^\([0-9.]*\)   excludes IPv6, which is checked before the
+        #     lladdr group is even consulted. It matters: an IPv6 neighbour
+        #     sharing the PEER's MAC would otherwise claim that MAC's
+        #     seen[] slot and hide the peer behind an unprobeable candidate.
+        #   \{17\}         excludes malformed lladdr values. Without it
+        #     "192.168.1.20 dev wlan0 lladdr INCOMPLETE" yields an empty
+        #     MAC key and awk then prints an empty candidate.
+        for NXP_IP in $(ip neigh 2>/dev/null | \
+                sed -n 's/^\([0-9.]*\) .*lladdr \([0-9a-f:]\{17\}\).*/\2 \1/p' | \
+                awk '!seen[$1]++ {print $2}'); do
+            nx_cancelled && return
+            [ "$NXP_IP" = "$NXP_MYIP" ] && continue
+            ( nx_probe "$NXP_IP" "$NXP_WANT" && : > "$NXP_HITS/$NXP_IP" ) &
+        done
+        # One probe's worth of wall clock rather than N probes' -- but note
+        # this function runs inside $( ), and a command substitution does
+        # not return until every background child it spawned has exited
+        # (they inherit the capture pipe). So the caller actually waits
+        # max(this sleep, slowest straggler probe). That is bounded: each
+        # nx_probe goes through nx_fetch's 3s watchdog. Measure the
+        # substitution, not this sleep, when timing a pass.
+        sleep 4
+        # Sorted so a re-run on an unchanged LAN picks the same peer.
+        NXP_FOUND=$(ls "$NXP_HITS" 2>/dev/null | sort | head -1)
+        rm -rf "$NXP_HITS"
+        if [ -n "$NXP_FOUND" ]; then
+            echo "$NXP_FOUND"
+            return
+        fi
+    done
+}
+
+nx_netplay_host() {
+    NXH_DATA="$USERDATA_DIR/data/flycast"
+    # Deliberately no progress value. This call and the -1 one below are
+    # both backgrounded and may still be waiting on show2's FIFO during
+    # its ~3-4s init, so their arrival order is not guaranteed. A numeric
+    # PROGRESS: landing after the -1 would cancel the marquee and freeze
+    # the bar for the whole discovery wait. Sending none means the only
+    # progress the daemon can see before that wait is -1, which makes this
+    # path deterministic and matches the client path.
+    nx_ui "Preparing saves..."
+    # One-deep crash insurance: the REAL card is live during a netplay
+    # session, so snapshot it first (~384 KB, overwritten each session).
+    mkdir -p "$USERDATA_DIR/netplay-backup"
+    cp -f "$NXH_DATA"/vmu_save_*.bin "$NXH_DATA/dc_nvmem.bin" \
+        "$USERDATA_DIR/netplay-backup/" 2>/dev/null
+    rm -rf "$NETPLAY_SRV"
+    mkdir -p "$NETPLAY_SRV"
+    printf '%s\nhost\n' "$EMU_OVERLAY_GAME" > "$NETPLAY_SRV/netplay-info"
+    (cd "$NXH_DATA" 2>/dev/null && \
+        tar cf "$NETPLAY_SRV/netplay-sync.tar" vmu_save_*.bin dc_nvmem.bin 2>/dev/null)
+    nx_serve_start
+    nx_cancelled && { NX_CANCELLED=1; return 0; }
+    # Computed here in the parent shell: nx_find_peer's own copy lives in
+    # a $( ) subshell and would always read back empty at this point.
+    NXH_NET=$(ip -4 addr show wlan0 2>/dev/null | \
+        sed -n 's|.*inet \([0-9.]*\)/24 .*|\1|p' | head -1)
+    if [ -n "$NXH_NET" ]; then NXH_WHERE="${NXH_NET%.*}.x"; else NXH_WHERE="the network"; fi
+    nx_ui "Looking for player 2 on $NXH_WHERE..." -1
+    NXH_PEER=$(nx_find_peer client)
+    if [ -n "$NXH_PEER" ]; then
+        nx_cfg_set network server "$NXH_PEER"
+        nx_ui "Player 2 found at $NXH_PEER" 90
+    else
+        nx_ui "No player 2 found - starting anyway" 100
+    fi
+    # No peer found: fail open on whatever server= already holds.
+}
+
+nx_netplay_client() {
+    NXC_NPDATA="$USERDATA_DIR/netplay-data/flycast"
+    mkdir -p "$NXC_NPDATA"
+    nx_ui "Looking for the host..." -1
+    # The client serves only its identity -- never any save data.
+    rm -rf "$NETPLAY_SRV"
+    mkdir -p "$NETPLAY_SRV"
+    printf '%s\nclient\n' "$EMU_OVERLAY_GAME" > "$NETPLAY_SRV/netplay-info"
+    nx_serve_start
+    nx_cancelled && { NX_CANCELLED=1; return 0; }
+    NXC_PEER=$(nx_find_peer host)
+    if [ -n "$NXC_PEER" ]; then
+        nx_cfg_set network server "$NXC_PEER"
+        nx_ui "Host found at $NXC_PEER - copying saves..." 60
+        nx_fetch "http://$NXC_PEER:$NETPLAY_PORT/netplay-sync.tar" 30 > /tmp/nx_netplay_sync.tar
+        # Tar-slip guard: the peer is discovered, not authenticated, and
+        # this script runs as root, so accept an archive only when ALL of
+        # these hold -- it lists at least one entry (a non-tar payload
+        # lists nothing, which would pass every negated test vacuously);
+        # every name is a bare expected filename (no slashes, no "..",
+        # no absolute paths); every mode column is "-"; and no entry is a
+        # link. The explicit link test is NOT redundant with the mode
+        # column: busybox tar prints a HARDLINK as "-" (only GNU tar uses
+        # "h"), so on this firmware the mode column alone would accept
+        # one. Both link kinds render their target as "name -> target".
+        # Without this a link named vmu_save_A1.bin could land in
+        # netplay-data and flycast would write VMU data through it.
+        if [ -s /tmp/nx_netplay_sync.tar ] && \
+           tar tf /tmp/nx_netplay_sync.tar 2>/dev/null | grep -q . && \
+           ! tar tf /tmp/nx_netplay_sync.tar 2>/dev/null | \
+             grep -qv '^vmu_save_[A-D][12]\.bin$\|^dc_nvmem\.bin$' && \
+           ! tar tvf /tmp/nx_netplay_sync.tar 2>/dev/null | \
+             grep -qv '^-' && \
+           ! tar tvf /tmp/nx_netplay_sync.tar 2>/dev/null | \
+             grep -q ' -> '; then
+            (cd "$NXC_NPDATA" && tar xf /tmp/nx_netplay_sync.tar 2>/dev/null)
+        fi
+        rm -f /tmp/nx_netplay_sync.tar
+    fi
+    [ -n "$NXC_PEER" ] || nx_ui "No host found - starting anyway" 100
+    # Borrowed-copy isolation: play on the synced copy; the client's real
+    # saves under data/flycast are never read or written during netplay.
+    #
+    # Cancelled means "play this game normally", so do NOT redirect saves
+    # to the borrowed netplay-data copy -- with GGPO off there is nothing
+    # to isolate, and the user would otherwise be playing single-player on
+    # the host's VMU instead of their own. (Their real saves are untouched
+    # either way; this is about which set the session actually uses.)
+    if nx_cancelled; then
+        NX_CANCELLED=1
+    else
+        export XDG_DATA_HOME="$USERDATA_DIR/netplay-data"
+    fi
+}
+
+if [ "$(nx_cfg_get network GGPO)" = "yes" ]; then
+    nx_ui_start "Starting..." "B = skip netplay"
+    nx_cancel_arm
+    # Plug a controller into DC port B. GGPO always drives port B as
+    # player 2 -- the REMOTE player on the host, the LOCAL player on the
+    # client (ggpo.cpp:500,569 make the local player localPlayerNum + 1;
+    # ggpo.cpp:643-650 writes inputState[player] straight to the maple
+    # port index) -- so BOTH machines need a pad there; that the client's
+    # own Start did nothing is exactly this. flycast leaves device2 =
+    # MDT_None (10) by default (option.cpp:197-201), so with port B empty
+    # those inputs reach no maple device and MvC2's VS mode stays greyed
+    # out. Both peers must carry the identical value or the emulated
+    # machines differ and desync -- which is why this is set here on both
+    # sides, not by hand.
+    nx_cfg_set input device2 0
+    # Close flycast's router port punching. EnableUPnP defaults to TRUE
+    # (option.cpp:172), and ggpo.cpp:801-804 runs miniupnp.Init() +
+    # AddPortMapping(19713/UDP) BEFORE the ActAsServer branch, so BOTH
+    # roles punch a mapping with an 86400 s lease (miniupnp.cpp). The
+    # seeded EnableUPnP = no in the default*.cfg files only reaches FRESH
+    # installs (it is gated behind .initialized), so no existing device
+    # ever gets it -- setting it here closes it everywhere. No
+    # restore-when-off branch is needed: the value is only consulted on
+    # the GGPO path.
+    nx_cfg_set network EnableUPnP no
+    if [ "$(nx_cfg_get network ActAsServer)" = "yes" ]; then
+        nx_netplay_host
+    else
+        nx_netplay_client
+    fi
+    if nx_cancelled; then
+        NX_CANCELLED=1
+        # nx_serve_start has already run in both role functions by the
+        # time a cancel is noticed, and on the host path the tar holds
+        # real VMU + dc_nvmem data. Without this the server keeps
+        # offering it on TCP 19714 until `wait $EMU_PID` returns -- i.e.
+        # for the whole session the user asked to spend NOT doing
+        # netplay. Tear it down here rather than in each role function.
+        if [ -n "$NX_HTTPD_PID" ]; then
+            kill "$NX_HTTPD_PID" 2>/dev/null
+            NX_HTTPD_PID=""
+        fi
+        rm -f /tmp/nx_netplay.pid
+        rm -rf "$NETPLAY_SRV"
+        nx_ui "Skipped - starting game..."
+        # nx_ui only QUEUES its write in a background subshell, and
+        # nx_ui_stop kills show2 immediately below, so without this pause
+        # the confirmation is never drawn -- pressing B would look exactly
+        # like nothing happening until flycast appears. One second is
+        # enough for the subshell to be scheduled, open the FIFO and for
+        # show2 to render a frame (it runs at 60 fps). This cost is paid
+        # ONLY on the cancel path, never on a normal launch.
+        sleep 1
+    fi
+    # Disarming deletes the flag file, so it MUST stay after the test
+    # above -- do not reorder these two.
+    nx_cancel_disarm
+    nx_ui_stop
+else
+    # Netplay off: unplug port B again so single-player sessions see the
+    # stock one-pad Dreamcast. It rewrites the key only when it currently
+    # holds this block's own value (0), so a user who deliberately
+    # configured another port-B device is not clobbered -- but a 0 set
+    # through flycast's own Controls UI for local two-pad play is
+    # indistinguishable from ours and does get reverted here.
+    [ "$(nx_cfg_get input device2)" = "0" ] && nx_cfg_set input device2 10
+fi
+# --- end netplay -------------------------------------------------------
+
 cd "$PAK_DIR"
-./flycast "$ROM" &> "$LOGS_PATH/$EMU_TAG.txt" &
+if [ -n "$NX_CANCELLED" ]; then
+    # Virtual config: flycast's get_entry() prefers virtual values and
+    # ConfigFile::save() never writes them, so this disables netplay for
+    # THIS RUN ONLY and emu.cfg is left byte-identical.
+    ./flycast -config network:GGPO=no "$ROM" &> "$LOGS_PATH/$EMU_TAG.txt" &
+else
+    ./flycast "$ROM" &> "$LOGS_PATH/$EMU_TAG.txt" &
+fi
 EMU_PID=$!
 
 # Thread pinning (cpu0-3 are all Cortex-A53 @ 2000 MHz). Evidence-based (see
@@ -192,4 +779,8 @@ kill -0 "$EMU_PID" 2>/dev/null && pin_threads
 wait $EMU_PID
 killall sleepmon.elf 2>/dev/null || true
 kill $SYNC_PID 2>/dev/null || true
+if [ -n "$NX_HTTPD_PID" ]; then
+    kill "$NX_HTTPD_PID" 2>/dev/null
+    rm -f /tmp/nx_netplay.pid
+fi
 echo 0 > /sys/class/speaker/mute 2>/dev/null || true

--- a/skeleton/EXTRAS/Emus/tg5040/DC.pak/netplay
+++ b/skeleton/EXTRAS/Emus/tg5040/DC.pak/netplay
@@ -1,0 +1,1 @@
+nextui marker: this pak supports "Y = Launch with Netplay" from the game list

--- a/skeleton/EXTRAS/Emus/tg5040/DC.pak/nx_paths.sh
+++ b/skeleton/EXTRAS/Emus/tg5040/DC.pak/nx_paths.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+# Shared by launch.sh and options.sh (sourced, not executed): resolve the
+# per-device config dir and seed emu.cfg on first use, so options can be
+# edited before a game has ever launched without the two scripts drifting.
+# Expects PAK_DIR to be set by the sourcing script.
+
+# User data (config per device, VMU + save states shared across devices)
+USERDATA_DIR="$SHARED_USERDATA_PATH/DC-flycast"
+if [ "$DEVICE" = "brick" ]; then
+    DEVICE_CONFIG_DIR="$USERDATA_DIR/config/tg5040-brick"
+    DEVICE_DEFAULT_CFG="$PAK_DIR/default-brick.cfg"
+elif [ "$DEVICE" = "brickpro" ]; then
+    DEVICE_CONFIG_DIR="$USERDATA_DIR/config/tg5040-brickpro"
+    DEVICE_DEFAULT_CFG="$PAK_DIR/default-brickpro.cfg"
+else
+    DEVICE_CONFIG_DIR="$USERDATA_DIR/config/tg5040-smart-pro"
+    DEVICE_DEFAULT_CFG="$PAK_DIR/default-smartpro.cfg"
+fi
+mkdir -p "$DEVICE_CONFIG_DIR/flycast/mappings" "$USERDATA_DIR/data/flycast"
+
+# First run: copy device-specific defaults
+if [ ! -f "$DEVICE_CONFIG_DIR/.initialized" ]; then
+    cp "$DEVICE_DEFAULT_CFG" "$DEVICE_CONFIG_DIR/flycast/emu.cfg"
+    touch "$DEVICE_CONFIG_DIR/.initialized"
+fi
+EMU_CFG="$DEVICE_CONFIG_DIR/flycast/emu.cfg"
+
+# Per-game override key. Multi-disc games live in a folder with a
+# folder-named .m3u (see BASE README); every disc of such a game maps to
+# ONE key -- the m3u/folder name -- mirroring how minarch normalizes
+# alt_name for its own per-game config (ma_game.c:110-136), except that
+# this pak's key convention drops the extension. Without this, the editor
+# (handed the .m3u by nextui) and launch.sh (handed a resolved first-disc
+# path by openRom) would write and read different override files.
+nx_rom_base() {
+    _dir="$(dirname "$1")"
+    _dirbase="${_dir##*/}"
+    if [ -f "$_dir/$_dirbase.m3u" ]; then
+        printf '%s' "$_dirbase"
+    else
+        _b="${1##*/}"
+        printf '%s' "${_b%.*}"
+    fi
+}

--- a/skeleton/EXTRAS/Emus/tg5040/DC.pak/options.sh
+++ b/skeleton/EXTRAS/Emus/tg5040/DC.pak/options.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# NAME: Dreamcast (Flycast)
+# Pre-launch options editor entry point. Its existence is also the capability
+# marker nextui probes for the "Emulator Options" context-menu entry (the
+# same pattern as the `netplay` marker file).
+# Usage: options.sh [rom-path]   (no arg: edit the device-global defaults)
+
+PAK_DIR="$(dirname "$0")"
+cd "$PAK_DIR"
+
+# Config-dir resolution + emu.cfg seeding shared with launch.sh
+. "$PAK_DIR/nx_paths.sh"
+
+JSON="$SDCARD_PATH/Emus/shared/flycast/overlay_settings.json"
+
+if [ -n "$1" ]; then
+    ROM="$1"
+    NX_ROM_BASE="$(nx_rom_base "$ROM")"
+    mkdir -p "$DEVICE_CONFIG_DIR/games"
+    options.elf --json "$JSON" --ini "$EMU_CFG" \
+        --override "$DEVICE_CONFIG_DIR/games/$NX_ROM_BASE.cfg" \
+        --game "$NX_ROM_BASE" 2> "$LOGS_PATH/emu-options.txt"
+else
+    options.elf --json "$JSON" --ini "$EMU_CFG" \
+        --game "Dreamcast (Flycast)" 2> "$LOGS_PATH/emu-options.txt"
+fi

--- a/skeleton/EXTRAS/Emus/tg5050/DC.pak/default.cfg
+++ b/skeleton/EXTRAS/Emus/tg5050/DC.pak/default.cfg
@@ -23,6 +23,14 @@ fullscreen = yes
 width = 1280
 height = 720
 
+[network]
+GGPO = no
+ActAsServer = no
+GGPODelay = 0
+DCNet = no
+EnableUPnP = no
+server =
+
 [achievements]
 Enabled = no
 HardcoreMode = no

--- a/skeleton/EXTRAS/Emus/tg5050/DC.pak/launch.sh
+++ b/skeleton/EXTRAS/Emus/tg5050/DC.pak/launch.sh
@@ -107,30 +107,16 @@ nx_pick_audio_rate() {
 # Dreamcast AICA is natively 44.1 kHz
 export NX_AUDIO_RATE=$(nx_pick_audio_rate 44100)
 
-# --- Netplay auto-sync + auto-discovery (GGPO) -------------------------
-# Runs only when [network] GGPO = yes in emu.cfg (the overlay's Netplay
-# section). BOTH devices serve a role-tagged netplay-info on TCP 19714
-# and BOTH scan the LAN for a peer running the same ROM in the OPPOSITE
-# role, because GGPO is peer-to-peer: each side must know the other's
-# address (ggpo.cpp:579-597 -- an empty server= makes flycast target
-# loopback on localPort ^ 1: 19712 from the host, 19713 from the client,
-# then wait forever on "Starting Network", which has no timeout, only a
-# Cancel button). v1 had the host learn the client's IP
-# passively from its own access log inside a pre-launch window; a client
-# that was late, absent, or launched first left the host hung. Scanning
-# on both sides makes launch order and timing irrelevant.
-#   host   - plays on its REAL VMU/flash and also serves a tar of exactly
-#            the GGPO-hashed files (vmu_save_*.bin + dc_nvmem.bin, see
-#            ggpo.cpp:537), so whoever hosts contributes their own saves
-#   client - pulls that tar into an isolated netplay-data dir and plays
-#            on the borrowed copy; its own saves are never touched
-# Every failure path falls through to a normal launch ("fail-open").
-# Design: docs/superpowers/specs/2026-07-28-netplay-state-sync-design.md
-NETPLAY_PORT=19714
-NETPLAY_SRV=/tmp/nx_netplay
-NETPLAY_LOG=/tmp/nx_netplay.log
-NETPLAY_DEADLINE=90
-NX_HTTPD_PID=""
+# --- Netplay (pre-launch wizard) ---------------------------------------
+# Netplay runs only when nextui wrote /tmp/netplay_launch (Y / "Launch
+# with Netplay" on a capable ROM). netplay.elf owns all setup UI: role,
+# hotspot/WiFi, peer discovery, and the rsync save sync (host serves its
+# VMU/flash read-only on TCP 18731; the client pulls into netplay-data).
+# Every netplay value below is passed as a VIRTUAL -config: flycast's
+# get_entry() prefers virtual values and ConfigFile::save() never writes
+# them, so emu.cfg is untouched by a netplay run. GGPODelay/DCNet remain
+# real overlay settings that flycast reads from emu.cfg itself.
+# Design: docs/superpowers/specs/2026-07-29-netplay-prelaunch-wizard-design.md
 
 # Read one key from one section of emu.cfg (empty when absent).
 nx_cfg_get() {
@@ -148,554 +134,83 @@ nx_cfg_set() {
     sed -i "/^\[$1\]/,/^\[/s|^$2 =.*|$2 = $3|" "$EMU_CFG"
 }
 
-# wget with a watchdog: busybox wget has no timeout flag, so kill it
-# ourselves after $2 seconds. Prints fetched content (empty on failure).
-nx_fetch() {
-    # Each discovery pass runs a dozen-plus nx_fetch calls CONCURRENTLY,
-    # and in POSIX sh `$$` keeps the PARENT shell's pid inside a subshell
-    # -- so a pid-derived name is the SAME file in every probe. Measured
-    # on-device: 16 concurrent probes against a network with exactly one
-    # real peer returned ZERO hits, because one probe's trailing `rm -f`
-    # deleted the payload another had just downloaded; the same race also
-    # made a dead host report a live host's payload and win the `ls |
-    # sort | head -1` selection. Both present as "stuck looking for
-    # player 2", and this is the other half of the first pair test's
-    # failure: fixing it ALONE would still have been swamped by the ~250
-    # concurrent probes the un-deduplicated neighbour list produced (see
-    # nx_find_peer). Both fixes are required.
-    #
-    # The name must be unique per invocation. mktemp is at
-    # /bin/mktemp on both devices; the fallback derives uniqueness from
-    # the URL, which is likewise distinct for every concurrent probe.
-    NXF_OUT=$(mktemp /tmp/nx_netplay_fetch.XXXXXX 2>/dev/null)
-    if [ -z "$NXF_OUT" ]; then
-        NXF_OUT=/tmp/nx_netplay_fetch.$(printf '%s' "$1" | tr -c 'a-zA-Z0-9' '_')
-        rm -f "$NXF_OUT"
-    fi
-    wget -q -O "$NXF_OUT" "$1" 2>/dev/null &
-    NXF_PID=$!
-    NXF_T=0
-    while [ "$NXF_T" -lt "$2" ]; do
-        kill -0 "$NXF_PID" 2>/dev/null || break
-        # Abort promptly on cancel: without this a press during the
-        # client's up-to-30s tar download would sit unnoticed until the
-        # download finished. Callers already treat an empty result as a
-        # failed fetch.
-        nx_cancelled && break
-        sleep 1
-        NXF_T=$((NXF_T+1))
-    done
-    kill "$NXF_PID" 2>/dev/null
-    wait "$NXF_PID" 2>/dev/null
-    cat "$NXF_OUT" 2>/dev/null
-    rm -f "$NXF_OUT"
+# Migration guard (idempotent): revert the two keys the old overlay-toggle
+# flow persisted that would still CHANGE a plain launch on an upgraded
+# card -- GGPO (would start netplay unasked) and device2 (would plug a
+# phantom pad into DC port B). This is deliberately NOT a full netplay-state
+# wipe: a stale `server = <ip>` (and `EnableUPnP = no`) written by a previous
+# real session is left in emu.cfg untouched. Both are harmless -- flycast
+# reads them only on the GGPO path, and on that path the virtual -config set
+# below overrides them anyway, since get_entry() prefers virtual values.
+# device2: a hand-set 0 (local two-pad) is indistinguishable from the old
+# block's and gets reverted ONCE; the new flow never writes it to disk.
+NX_G="$(nx_cfg_get network GGPO)"
+if [ "$NX_G" = "yes" ] || [ "$NX_G" = "True" ]; then
+    nx_cfg_set network GGPO no
+fi
+[ "$(nx_cfg_get input device2)" = "0" ] && nx_cfg_set input device2 10
+
+# Both early exits below leave the script BEFORE `wait $EMU_PID`, skipping
+# the teardown at the bottom -- and sleepmon.elf, the unmute subshell
+# ($SYNC_PID) and the pre-launch mute are all started ABOVE this block. An
+# orphaned sleepmon.elf left running in the game list keeps its own
+# long-press power handler armed (killall -TERM nextui.elf, then an
+# unconditional poweroff), so an early exit MUST undo them itself. The old
+# netplay block never exited early -- even its cancel arm fell through to
+# flycast, so the teardown at the bottom always ran.
+nx_netplay_bail() {
+    killall sleepmon.elf 2>/dev/null || true
+    kill $SYNC_PID 2>/dev/null || true
+    echo 0 > /sys/class/speaker/mute 2>/dev/null || true
+    exit 0
 }
 
-# --- status display -----------------------------------------------------
-# Drives show2.elf (already shipped in $SYSTEM_PATH/bin) in daemon mode so
-# the long discovery phase is not a silent black screen. show2 renders via
-# SDL2/DRM -- /dev/fb0 is NOT the display path on these devices, so a
-# framebuffer-writing helper would draw nothing. Every call here is a
-# guarded no-op when show2.elf is missing or its daemon died: discovery and
-# launch must never block or fail because of the UI.
-NX_UI_FIFO=/tmp/show2.fifo
-NX_UI_ON=""
-
-NX_CANCEL_FLAG=/tmp/nx_netplay_cancel
-NX_CANCEL_BTN=00          # physical B. Measured on a Brick 2026-07-29:
-                          # five presses, all "01 00 01 00" (value 0001,
-                          # type 01, number 00). Agrees with this pak's own
-                          # SDL_Xbox 360 Controller.cfg (bind0 = 0:btn_b).
-NX_CANCEL_PID=""
-NX_CANCELLED=""
-
-nx_ui_start() {
-    # Resolved via PATH ($SYSTEM_PATH/bin), exactly like this script's own
-    # bare sleepmon.elf / syncsettings.elf / taskset calls. Do NOT build a
-    # $SDCARD_PATH/.system/<platform>/bin path here: that differs per device
-    # and this block must stay byte-identical across both launch.sh files.
-    command -v show2.elf >/dev/null 2>&1 || return 0
-    rm -f "$NX_UI_FIFO"
-    # show2 needs libSDL2 from $SDCARD_PATH/.system/<platform>/lib, which
-    # launch.sh already put on LD_LIBRARY_PATH above; without it show2
-    # aborts with "libSDL2-2.0.so.0: cannot open shared object file".
-    # --image is mandatory but we have no netplay artwork; /dev/null is the
-    # repo's existing "no logo" idiom (see PortMaster's progressor).
-    # --progress=-1 selects show2's indeterminate marquee (show2.cpp:424),
-    # which is what the install boot.sh uses for exactly this kind of
-    # unknown-length wait -- an empty 0% bar would just look stalled.
-    if [ -n "$2" ]; then
-        show2.elf --mode=daemon --image=/dev/null --bgcolor=0x000000 \
-            --progress=-1 --text="$1" --hint="$2" >/dev/null 2>&1 &
+NETPLAY_ARGS=""
+if [ -f /tmp/netplay_launch ]; then
+    rm -f /tmp/netplay_launch
+    netplay.elf --game "$EMU_OVERLAY_GAME" \
+        --serve-dir "$USERDATA_DIR/data/flycast" \
+        --fetch-to "$USERDATA_DIR/netplay-data/flycast" \
+        --fetch-files "vmu_save_*.bin,dc_nvmem.bin" \
+        &> "$LOGS_PATH/netplay-wizard.txt"
+    if [ $? -ne 0 ]; then
+        # cancelled or failed: back to the game list, never a peerless
+        # GGPO launch (single-player is one A press away)
+        nx_netplay_bail
+    fi
+    # Defensive: exit 0 is the wizard's "start with netplay" contract and it
+    # unlinks a half-written session before failing, so a missing file here
+    # is an anomaly -- but sourcing an absent file is FATAL in ash, which
+    # would take the whole launch down. Bail to the game list instead.
+    [ -f /tmp/netplay_session ] || nx_netplay_bail
+    . /tmp/netplay_session
+    if [ "$NETPLAY_ROLE" = "host" ]; then
+        # host plays on its REAL VMU/flash ("host brings the memory
+        # card"); keep a one-deep pre-session copy for manual recovery,
+        # overwritten every hosted session
+        mkdir -p "$USERDATA_DIR/netplay-backup"
+        cp -f "$USERDATA_DIR/data/flycast"/vmu_save_*.bin \
+              "$USERDATA_DIR/data/flycast/dc_nvmem.bin" \
+              "$USERDATA_DIR/netplay-backup/" 2>/dev/null
+        NX_AS_SERVER=yes
     else
-        show2.elf --mode=daemon --image=/dev/null --bgcolor=0x000000 \
-            --progress=-1 --text="$1" >/dev/null 2>&1 &
-    fi
-    NX_UI_ON=$!
-    # Daemon needs ~3-4s (SDL2 + DRM init) before it paints; do not wait
-    # for it here -- the network work below overlaps that cost.
-}
-
-# nx_ui "<message>" [progress 0-100]
-# Opening a FIFO for writing BLOCKS until a reader attaches, so a daemon
-# that died while leaving its FIFO node behind would hang the launch
-# forever on the next status update -- the exact failure this feature
-# exists to prevent. Two defences: skip when the daemon PID is gone, and
-# do the write in a background subshell so even a lost race can only
-# strand that subshell, never the script.
-nx_ui() {
-    [ -n "$NX_UI_ON" ] || return 0
-    kill -0 "$NX_UI_ON" 2>/dev/null || return 0
-    # show2 creates the FIFO only after its SDL2/DRM init: mkfifo is the
-    # first statement of runDaemonMode(), which runs after initialize()
-    # returns (~3-4s). A plain [ -p ] test here would therefore DROP every
-    # early message -- and those are the ones that matter, because the next
-    # update can be up to NETPLAY_DEADLINE seconds later. So wait for the
-    # node, but do it INSIDE the background subshell so the script itself
-    # never stalls. Ordering between messages queued during that init
-    # window is not guaranteed; they all land within a second of each
-    # other and only the last is visible, which is acceptable here.
-    ( NXU_T=0
-      while [ ! -p "$NX_UI_FIFO" ] && [ "$NXU_T" -lt 10 ]; do
-          kill -0 "$NX_UI_ON" 2>/dev/null || exit 0
-          sleep 1
-          NXU_T=$((NXU_T+1))
-      done
-      [ -p "$NX_UI_FIFO" ] || exit 0
-      printf 'TEXT:%s\n' "$1" > "$NX_UI_FIFO" 2>/dev/null
-      [ -n "$2" ] && printf 'PROGRESS:%s\n' "$2" > "$NX_UI_FIFO" 2>/dev/null
-      : ) &
-    return 0
-}
-
-nx_ui_stop() {
-    [ -n "$NX_UI_ON" ] || return 0
-    # Same blocking hazard as nx_ui, and worse here: this is the LAST
-    # statement before flycast launches, so a dead daemon that left its
-    # FIFO node behind would hang the launch at the finish line. Guard on
-    # liveness and background the write. killall is the real cleanup --
-    # it cannot block -- and the QUIT is only the graceful path.
-    if kill -0 "$NX_UI_ON" 2>/dev/null && [ -p "$NX_UI_FIFO" ]; then
-        ( printf 'QUIT\n' > "$NX_UI_FIFO" 2>/dev/null ) &
-    fi
-    # Belt-and-braces: nothing may hold the display against flycast.
-    # MUST be -9. Measured on a Brick 2026-07-29: after a plain SIGTERM the
-    # daemon was still alive 6 s later; SIGKILL ended it instantly. show2
-    # installs a handler for SIGINT only (show2.cpp:623) and SDL_Init traps
-    # SIGTERM into an SDL_QUIT event that show2 never pumps (it has no
-    # SDL_PollEvent at all), so SIGTERM is swallowed. MinUI.pak's own
-    # launch.sh:228 has always used -9 on this same binary.
-    killall -9 show2.elf 2>/dev/null
-    # Leave no stale node for the next launch to trip over.
-    rm -f "$NX_UI_FIFO" 2>/dev/null
-    NX_UI_ON=""
-    return 0
-}
-
-# --- cancel (press B to skip netplay) ----------------------------------
-# True once the user has asked to skip netplay.
-nx_cancelled() { [ -f "$NX_CANCEL_FLAG" ]; }
-
-# Watch the gamepad for a B press and drop a flag file.
-#
-# js0 delivers 8-byte events: u32 time, s16 value, u8 type, u8 number. A
-# real press is type 01 with a non-zero value; opening the device emits an
-# init burst (type 81/82, value 0) and releases carry value 0, so neither
-# can trigger a cancel, and stick movement (type 02) cannot either.
-#
-# Two shapes were tried on-device and BOTH failed; do not "simplify" back
-# to either:
-#   dd if=js0 | hexdump | while read   -- hexdump BLOCK-BUFFERS to a pipe,
-#     so presses sit unseen until ~4KB (~170 events) accumulates. A 45s
-#     capture recorded zero presses while buttons were being pressed.
-#   dd if=js0 count=1 inside a loop    -- re-opens the device every pass,
-#     replaying the init burst each time, and spins.
-# What works: open ONCE on fd 3, then one short-lived dd/hexdump per event
-# so hexdump exits (and therefore flushes) every time. Verified: presses
-# appear immediately and the loop blocks without spinning when idle.
-#
-# od is not on this firmware; hexdump is. Backgrounded so it can never
-# delay the launch. If js0 is unreadable the subshell exits at once and
-# cancel is simply unavailable -- every other path is unchanged.
-nx_cancel_arm() {
-    rm -f "$NX_CANCEL_FLAG"
-    [ -r /dev/input/js0 ] || return 0
-    (
-        exec 3< /dev/input/js0 || exit 0
-        while :; do
-            NXB_EV=$(dd bs=8 count=1 <&3 2>/dev/null | hexdump -v -e '8/1 "%02x " "\n"')
-            [ -n "$NXB_EV" ] || exit 0
-            set -- $NXB_EV
-            [ "$7" = "01" ] || continue
-            [ "$8" = "$NX_CANCEL_BTN" ] || continue
-            [ "$5$6" = "0000" ] && continue
-            : > "$NX_CANCEL_FLAG"
-            exit 0
-        done
-    ) &
-    NX_CANCEL_PID=$!
-    return 0
-}
-
-# Stop watching.
-#
-# Killing the subshell does NOT reap its children: the blocked dd, the
-# command-substitution child and hexdump each keep js0 open. That leak is
-# deliberately accepted rather than swept, and the reasoning is worth
-# keeping because both obvious sweeps are wrong here:
-#
-#   - Matching /proc/<pid>/cmdline cannot work. The device is opened with
-#     `exec 3< /dev/input/js0` and read with `dd bs=8 count=1 <&3`, so the
-#     path is a redirection, never an argument -- busybox ps shows the dd
-#     as "dd bs 8 count 1". Verified on-device: an argv sweep finds none of
-#     the holders.
-#   - Matching open descriptors (readlink /proc/<pid>/fd/*) DOES find them
-#     all -- also verified on-device -- but "kill whatever holds js0" is
-#     dangerous: keymon.elf opens input devices and runs throughout the
-#     game, and killing the launcher is known to power this device off.
-#     A cleanup that can kill the launcher is not worth a leak that clears
-#     itself.
-#
-# And it does clear itself: dd was started with count=1, so the first
-# controller event after flycast starts makes it read one event and exit,
-# hexdump then sees EOF, and the substitution child follows. joydev gives
-# each opener an independent event buffer, so nothing is taken from
-# flycast in the meantime.
-nx_cancel_disarm() {
-    [ -n "$NX_CANCEL_PID" ] && kill "$NX_CANCEL_PID" 2>/dev/null
-    NX_CANCEL_PID=""
-    rm -f "$NX_CANCEL_FLAG"
-    return 0
-}
-
-# Serve $NETPLAY_SRV on 19714 with whatever this firmware provides:
-# busybox httpd (tg5040) or python3 http.server (tg5050, whose busybox
-# 1.35 ships no httpd applet). Neither present -> no server, fail open.
-# httpd runs without -v, so there is no request log at all: $NETPLAY_LOG
-# only ever holds the server's own stdout/stderr (empty on tg5040). It
-# still lives OUTSIDE the serve dir so it is never itself served.
-# Must run in the parent shell, never inside $( ) -- NX_HTTPD_PID has to
-# survive for the cleanup block after wait $EMU_PID.
-nx_serve_start() {
-    # The pidfile is only removed on a clean exit, so a power-off or a
-    # hybrid-sleep leaves a stale one behind and the pid it names may have
-    # been recycled onto an unrelated process by the next launch. Blind
-    # SIGTERM to a recycled pid is a genuinely bad outcome on this device
-    # family, so confirm the pid is actually one of our servers before
-    # signalling it: /proc/<pid>/comm reads "httpd" or "python3" (the
-    # python path execs, so the subshell is replaced and comm is the
-    # interpreter, not sh). The pidfile goes either way -- a pid we
-    # decline to kill is not ours to keep tracking.
-    #
-    # BOTH stages are needed; the digits test alone is not enough. It
-    # accepts "0", and `kill 0` signals EVERY process in our process
-    # group. That is unreachable only because /proc/0/comm does not
-    # exist, so the comm test rejects it -- do not drop that test.
-    if [ -f /tmp/nx_netplay.pid ]; then
-        NXS_OLD=$(cat /tmp/nx_netplay.pid 2>/dev/null)
-        case "$NXS_OLD" in
-            ""|*[!0-9]*) ;;
-            *)
-                # A zero pid passes the all-digits test above, and
-                # `kill 0` signals EVERY process in this script's process
-                # group -- on this device family that reaches the
-                # launcher, and killing the launcher powers the unit off.
-                # /proc/0/comm not existing does block it today, but a
-                # guard against that blast radius should not rest on one
-                # accident. Test arithmetically rather than matching a
-                # literal 0: "00" is also zero and slips past a pattern.
-                if [ "$NXS_OLD" -gt 0 ]; then
-                    case "$(cat "/proc/$NXS_OLD/comm" 2>/dev/null)" in
-                        httpd|python3) kill "$NXS_OLD" 2>/dev/null ;;
-                    esac
-                fi
-                ;;
-        esac
-        rm -f /tmp/nx_netplay.pid
-    fi
-    if command -v httpd >/dev/null 2>&1; then
-        httpd -f -p "$NETPLAY_PORT" -h "$NETPLAY_SRV" > "$NETPLAY_LOG" 2>&1 &
-        NX_HTTPD_PID=$!
-    elif command -v python3 >/dev/null 2>&1; then
-        ( cd "$NETPLAY_SRV" && exec python3 -u -m http.server "$NETPLAY_PORT" ) \
-            > "$NETPLAY_LOG" 2>&1 &
-        NX_HTTPD_PID=$!
-    fi
-    [ -n "$NX_HTTPD_PID" ] && echo "$NX_HTTPD_PID" > /tmp/nx_netplay.pid
-}
-
-# True when $1 serves a netplay-info for this ROM in role $2. The role
-# line is what stops two hosts (or two clients) from pairing, and the
-# ROM line stops cross-game pairing.
-nx_probe() {
-    NXI=$(nx_fetch "http://$1:$NETPLAY_PORT/netplay-info" 3)
-    [ "$(printf '%s\n' "$NXI" | sed -n 1p)" = "$EMU_OVERLAY_GAME" ] && \
-    [ "$(printf '%s\n' "$NXI" | sed -n 2p)" = "$2" ]
-}
-
-# Print the IP of a peer in role $1, or nothing. Tries the stored server=
-# first, but only when it is in our current /24 -- after a relocation the
-# stored address belongs to the old network and can never answer, so
-# probing it just burns ~3s. Then ping-sweeps the /24 and probes every
-# neighbour CONCURRENTLY: serial probes cost >=1s each (nx_fetch's poll
-# floor), so a LAN with N reachable hosts used to cost ~N seconds per
-# pass. Runs inside $( ) -- it must not set anything the caller needs.
-nx_find_peer() {
-    NXP_WANT=$1
-    NXP_MYIP=$(ip -4 addr show wlan0 2>/dev/null | \
-        sed -n 's|.*inet \([0-9.]*\)/24 .*|\1|p' | head -1)
-    NXP_NET=${NXP_MYIP%.*}
-    NXP_STORED=$(nx_cfg_get network server)
-    if [ -n "$NXP_STORED" ] && [ -n "$NXP_NET" ] && \
-       [ "${NXP_STORED%.*}" = "$NXP_NET" ] && \
-       nx_probe "$NXP_STORED" "$NXP_WANT"; then
-        echo "$NXP_STORED"
-        return
-    fi
-    NXP_HITS=/tmp/nx_netplay_hits
-    NXP_END=$(( $(date +%s) + NETPLAY_DEADLINE ))
-    while [ "$(date +%s)" -lt "$NXP_END" ]; do
-        nx_cancelled && return
-        if [ -n "$NXP_NET" ]; then
-            NXP_I=1
-            while [ "$NXP_I" -le 254 ]; do
-                ping -c1 -W1 "$NXP_NET.$NXP_I" >/dev/null 2>&1 &
-                NXP_I=$((NXP_I+1))
-            done
-            sleep 3
-        else
-            # No /24 sweep to pace the loop; without this an empty
-            # neighbour table would spin the deadline loop hot.
-            sleep 1
-        fi
-        rm -rf "$NXP_HITS"
-        mkdir -p "$NXP_HITS"
-        # A /24 sweep leaves an ARP entry for EVERY address it probed, and
-        # a router that answers ARP for unused addresses turns that into
-        # hundreds of entries sharing a handful of MACs. Probing all of
-        # them spawns hundreds of concurrent wgets on a 4-core handheld,
-        # none finish inside the collect window below, and the peer is
-        # never found -- one half of how the first real pair test failed.
-        # The other half is nx_fetch's shared temp file (see there): dedup
-        # ALONE cannot fix discovery, because that race destroys the
-        # result at any concurrency.
-        #
-        # Deduplicate by MAC: one candidate per physical device. Measured
-        # on-device, as one dataset through the two filter stages:
-        #   raw `ip neigh`                     259 lines, ~19 MACs
-        #   after the IPv4 + valid-lladdr sed  222 lines,  16 MACs
-        # so 16 candidates survive, the real peer among them -- phantoms
-        # share the router's MAC, real devices each keep their own.
-        #
-        # awk rather than `sort -u -k1,1` because a busybox built without
-        # CONFIG_FEATURE_SORT_BIG has no `-k` at all; where `-k` exists,
-        # `sort -u` does honour it (verified on tg5050).
-        #
-        # Both sed anchors are load-bearing, and they earn their keep on
-        # different inputs:
-        #   ^\([0-9.]*\)   excludes IPv6, which is checked before the
-        #     lladdr group is even consulted. It matters: an IPv6 neighbour
-        #     sharing the PEER's MAC would otherwise claim that MAC's
-        #     seen[] slot and hide the peer behind an unprobeable candidate.
-        #   \{17\}         excludes malformed lladdr values. Without it
-        #     "192.168.1.20 dev wlan0 lladdr INCOMPLETE" yields an empty
-        #     MAC key and awk then prints an empty candidate.
-        for NXP_IP in $(ip neigh 2>/dev/null | \
-                sed -n 's/^\([0-9.]*\) .*lladdr \([0-9a-f:]\{17\}\).*/\2 \1/p' | \
-                awk '!seen[$1]++ {print $2}'); do
-            nx_cancelled && return
-            [ "$NXP_IP" = "$NXP_MYIP" ] && continue
-            ( nx_probe "$NXP_IP" "$NXP_WANT" && : > "$NXP_HITS/$NXP_IP" ) &
-        done
-        # One probe's worth of wall clock rather than N probes' -- but note
-        # this function runs inside $( ), and a command substitution does
-        # not return until every background child it spawned has exited
-        # (they inherit the capture pipe). So the caller actually waits
-        # max(this sleep, slowest straggler probe). That is bounded: each
-        # nx_probe goes through nx_fetch's 3s watchdog. Measure the
-        # substitution, not this sleep, when timing a pass.
-        sleep 4
-        # Sorted so a re-run on an unchanged LAN picks the same peer.
-        NXP_FOUND=$(ls "$NXP_HITS" 2>/dev/null | sort | head -1)
-        rm -rf "$NXP_HITS"
-        if [ -n "$NXP_FOUND" ]; then
-            echo "$NXP_FOUND"
-            return
-        fi
-    done
-}
-
-nx_netplay_host() {
-    NXH_DATA="$USERDATA_DIR/data/flycast"
-    # Deliberately no progress value. This call and the -1 one below are
-    # both backgrounded and may still be waiting on show2's FIFO during
-    # its ~3-4s init, so their arrival order is not guaranteed. A numeric
-    # PROGRESS: landing after the -1 would cancel the marquee and freeze
-    # the bar for the whole discovery wait. Sending none means the only
-    # progress the daemon can see before that wait is -1, which makes this
-    # path deterministic and matches the client path.
-    nx_ui "Preparing saves..."
-    # One-deep crash insurance: the REAL card is live during a netplay
-    # session, so snapshot it first (~384 KB, overwritten each session).
-    mkdir -p "$USERDATA_DIR/netplay-backup"
-    cp -f "$NXH_DATA"/vmu_save_*.bin "$NXH_DATA/dc_nvmem.bin" \
-        "$USERDATA_DIR/netplay-backup/" 2>/dev/null
-    rm -rf "$NETPLAY_SRV"
-    mkdir -p "$NETPLAY_SRV"
-    printf '%s\nhost\n' "$EMU_OVERLAY_GAME" > "$NETPLAY_SRV/netplay-info"
-    (cd "$NXH_DATA" 2>/dev/null && \
-        tar cf "$NETPLAY_SRV/netplay-sync.tar" vmu_save_*.bin dc_nvmem.bin 2>/dev/null)
-    nx_serve_start
-    nx_cancelled && { NX_CANCELLED=1; return 0; }
-    # Computed here in the parent shell: nx_find_peer's own copy lives in
-    # a $( ) subshell and would always read back empty at this point.
-    NXH_NET=$(ip -4 addr show wlan0 2>/dev/null | \
-        sed -n 's|.*inet \([0-9.]*\)/24 .*|\1|p' | head -1)
-    if [ -n "$NXH_NET" ]; then NXH_WHERE="${NXH_NET%.*}.x"; else NXH_WHERE="the network"; fi
-    nx_ui "Looking for player 2 on $NXH_WHERE..." -1
-    NXH_PEER=$(nx_find_peer client)
-    if [ -n "$NXH_PEER" ]; then
-        nx_cfg_set network server "$NXH_PEER"
-        nx_ui "Player 2 found at $NXH_PEER" 90
-    else
-        nx_ui "No player 2 found - starting anyway" 100
-    fi
-    # No peer found: fail open on whatever server= already holds.
-}
-
-nx_netplay_client() {
-    NXC_NPDATA="$USERDATA_DIR/netplay-data/flycast"
-    mkdir -p "$NXC_NPDATA"
-    nx_ui "Looking for the host..." -1
-    # The client serves only its identity -- never any save data.
-    rm -rf "$NETPLAY_SRV"
-    mkdir -p "$NETPLAY_SRV"
-    printf '%s\nclient\n' "$EMU_OVERLAY_GAME" > "$NETPLAY_SRV/netplay-info"
-    nx_serve_start
-    nx_cancelled && { NX_CANCELLED=1; return 0; }
-    NXC_PEER=$(nx_find_peer host)
-    if [ -n "$NXC_PEER" ]; then
-        nx_cfg_set network server "$NXC_PEER"
-        nx_ui "Host found at $NXC_PEER - copying saves..." 60
-        nx_fetch "http://$NXC_PEER:$NETPLAY_PORT/netplay-sync.tar" 30 > /tmp/nx_netplay_sync.tar
-        # Tar-slip guard: the peer is discovered, not authenticated, and
-        # this script runs as root, so accept an archive only when ALL of
-        # these hold -- it lists at least one entry (a non-tar payload
-        # lists nothing, which would pass every negated test vacuously);
-        # every name is a bare expected filename (no slashes, no "..",
-        # no absolute paths); every mode column is "-"; and no entry is a
-        # link. The explicit link test is NOT redundant with the mode
-        # column: busybox tar prints a HARDLINK as "-" (only GNU tar uses
-        # "h"), so on this firmware the mode column alone would accept
-        # one. Both link kinds render their target as "name -> target".
-        # Without this a link named vmu_save_A1.bin could land in
-        # netplay-data and flycast would write VMU data through it.
-        if [ -s /tmp/nx_netplay_sync.tar ] && \
-           tar tf /tmp/nx_netplay_sync.tar 2>/dev/null | grep -q . && \
-           ! tar tf /tmp/nx_netplay_sync.tar 2>/dev/null | \
-             grep -qv '^vmu_save_[A-D][12]\.bin$\|^dc_nvmem\.bin$' && \
-           ! tar tvf /tmp/nx_netplay_sync.tar 2>/dev/null | \
-             grep -qv '^-' && \
-           ! tar tvf /tmp/nx_netplay_sync.tar 2>/dev/null | \
-             grep -q ' -> '; then
-            (cd "$NXC_NPDATA" && tar xf /tmp/nx_netplay_sync.tar 2>/dev/null)
-        fi
-        rm -f /tmp/nx_netplay_sync.tar
-    fi
-    [ -n "$NXC_PEER" ] || nx_ui "No host found - starting anyway" 100
-    # Borrowed-copy isolation: play on the synced copy; the client's real
-    # saves under data/flycast are never read or written during netplay.
-    #
-    # Cancelled means "play this game normally", so do NOT redirect saves
-    # to the borrowed netplay-data copy -- with GGPO off there is nothing
-    # to isolate, and the user would otherwise be playing single-player on
-    # the host's VMU instead of their own. (Their real saves are untouched
-    # either way; this is about which set the session actually uses.)
-    if nx_cancelled; then
-        NX_CANCELLED=1
-    else
+        # client plays on the borrowed copy; its own saves are untouched
+        mkdir -p "$USERDATA_DIR/netplay-data/flycast"
         export XDG_DATA_HOME="$USERDATA_DIR/netplay-data"
+        NX_AS_SERVER=no
     fi
-}
-
-if [ "$(nx_cfg_get network GGPO)" = "yes" ]; then
-    nx_ui_start "Starting..." "B = skip netplay"
-    nx_cancel_arm
-    # Plug a controller into DC port B. GGPO always drives port B as
-    # player 2 -- the REMOTE player on the host, the LOCAL player on the
-    # client (ggpo.cpp:500,569 make the local player localPlayerNum + 1;
-    # ggpo.cpp:643-650 writes inputState[player] straight to the maple
-    # port index) -- so BOTH machines need a pad there; that the client's
-    # own Start did nothing is exactly this. flycast leaves device2 =
-    # MDT_None (10) by default (option.cpp:197-201), so with port B empty
-    # those inputs reach no maple device and MvC2's VS mode stays greyed
-    # out. Both peers must carry the identical value or the emulated
-    # machines differ and desync -- which is why this is set here on both
-    # sides, not by hand.
-    nx_cfg_set input device2 0
-    # Close flycast's router port punching. EnableUPnP defaults to TRUE
-    # (option.cpp:172), and ggpo.cpp:801-804 runs miniupnp.Init() +
-    # AddPortMapping(19713/UDP) BEFORE the ActAsServer branch, so BOTH
-    # roles punch a mapping with an 86400 s lease (miniupnp.cpp). The
-    # seeded EnableUPnP = no in the default*.cfg files only reaches FRESH
-    # installs (it is gated behind .initialized), so no existing device
-    # ever gets it -- setting it here closes it everywhere. No
-    # restore-when-off branch is needed: the value is only consulted on
-    # the GGPO path.
-    nx_cfg_set network EnableUPnP no
-    if [ "$(nx_cfg_get network ActAsServer)" = "yes" ]; then
-        nx_netplay_host
-    else
-        nx_netplay_client
-    fi
-    if nx_cancelled; then
-        NX_CANCELLED=1
-        # nx_serve_start has already run in both role functions by the
-        # time a cancel is noticed, and on the host path the tar holds
-        # real VMU + dc_nvmem data. Without this the server keeps
-        # offering it on TCP 19714 until `wait $EMU_PID` returns -- i.e.
-        # for the whole session the user asked to spend NOT doing
-        # netplay. Tear it down here rather than in each role function.
-        if [ -n "$NX_HTTPD_PID" ]; then
-            kill "$NX_HTTPD_PID" 2>/dev/null
-            NX_HTTPD_PID=""
-        fi
-        rm -f /tmp/nx_netplay.pid
-        rm -rf "$NETPLAY_SRV"
-        nx_ui "Skipped - starting game..."
-        # nx_ui only QUEUES its write in a background subshell, and
-        # nx_ui_stop kills show2 immediately below, so without this pause
-        # the confirmation is never drawn -- pressing B would look exactly
-        # like nothing happening until flycast appears. One second is
-        # enough for the subshell to be scheduled, open the FIFO and for
-        # show2 to render a frame (it runs at 60 fps). This cost is paid
-        # ONLY on the cancel path, never on a normal launch.
-        sleep 1
-    fi
-    # Disarming deletes the flag file, so it MUST stay after the test
-    # above -- do not reorder these two.
-    nx_cancel_disarm
-    nx_ui_stop
-else
-    # Netplay off: unplug port B again so single-player sessions see the
-    # stock one-pad Dreamcast. It rewrites the key only when it currently
-    # holds this block's own value (0), so a user who deliberately
-    # configured another port-B device is not clobbered -- but a 0 set
-    # through flycast's own Controls UI for local two-pad play is
-    # indistinguishable from ours and does get reverted here.
-    [ "$(nx_cfg_get input device2)" = "0" ] && nx_cfg_set input device2 10
+    # device2=0 plugs a pad into DC port B on BOTH sides (GGPO drives
+    # port B as player 2 -- remote on the host, LOCAL on the client);
+    # EnableUPnP=no stops ggpo.cpp:801-804 punching a router mapping.
+    NETPLAY_ARGS="-config network:GGPO=yes -config network:ActAsServer=$NX_AS_SERVER -config network:server=$NETPLAY_PEER_IP -config network:EnableUPnP=no -config input:device2=0"
 fi
 # --- end netplay -------------------------------------------------------
 
 cd "$PAK_DIR"
-if [ -n "$NX_CANCELLED" ]; then
-    # Virtual config: flycast's get_entry() prefers virtual values and
-    # ConfigFile::save() never writes them, so this disables netplay for
-    # THIS RUN ONLY and emu.cfg is left byte-identical.
-    ./flycast -config network:GGPO=no "$ROM" &> "$LOGS_PATH/$EMU_TAG.txt" &
-else
-    ./flycast "$ROM" &> "$LOGS_PATH/$EMU_TAG.txt" &
-fi
+# $NETPLAY_ARGS is deliberately UNQUOTED: it is a word-split argument list
+# (-config pairs) whose values contain no whitespace, and it is empty on
+# every normal launch, where it word-splits to nothing at all.
+./flycast $NETPLAY_ARGS "$ROM" &> "$LOGS_PATH/$EMU_TAG.txt" &
 EMU_PID=$!
 
 # Thread pinning (dual cluster). Evidence-based (see task-11 report): tg5040
@@ -766,8 +281,9 @@ kill -0 "$EMU_PID" 2>/dev/null && pin_threads
 wait $EMU_PID
 killall sleepmon.elf 2>/dev/null || true
 kill $SYNC_PID 2>/dev/null || true
-if [ -n "$NX_HTTPD_PID" ]; then
-    kill "$NX_HTTPD_PID" 2>/dev/null
-    rm -f /tmp/nx_netplay.pid
-fi
+# Netplay teardown: the session file is the only marker that this run went
+# through the wizard, so its presence gates the whole thing. --cleanup stops
+# the host's rsyncd, tears down a hotspot AP, restores the previous WiFi
+# network, and removes /tmp/netplay_session. Harmless on a plain launch.
+[ -f /tmp/netplay_session ] && netplay.elf --cleanup >> "$LOGS_PATH/netplay-wizard.txt" 2>&1
 echo 0 > /sys/class/speaker/mute 2>/dev/null || true

--- a/skeleton/EXTRAS/Emus/tg5050/DC.pak/launch.sh
+++ b/skeleton/EXTRAS/Emus/tg5050/DC.pak/launch.sh
@@ -107,8 +107,595 @@ nx_pick_audio_rate() {
 # Dreamcast AICA is natively 44.1 kHz
 export NX_AUDIO_RATE=$(nx_pick_audio_rate 44100)
 
+# --- Netplay auto-sync + auto-discovery (GGPO) -------------------------
+# Runs only when [network] GGPO = yes in emu.cfg (the overlay's Netplay
+# section). BOTH devices serve a role-tagged netplay-info on TCP 19714
+# and BOTH scan the LAN for a peer running the same ROM in the OPPOSITE
+# role, because GGPO is peer-to-peer: each side must know the other's
+# address (ggpo.cpp:579-597 -- an empty server= makes flycast target
+# loopback on localPort ^ 1: 19712 from the host, 19713 from the client,
+# then wait forever on "Starting Network", which has no timeout, only a
+# Cancel button). v1 had the host learn the client's IP
+# passively from its own access log inside a pre-launch window; a client
+# that was late, absent, or launched first left the host hung. Scanning
+# on both sides makes launch order and timing irrelevant.
+#   host   - plays on its REAL VMU/flash and also serves a tar of exactly
+#            the GGPO-hashed files (vmu_save_*.bin + dc_nvmem.bin, see
+#            ggpo.cpp:537), so whoever hosts contributes their own saves
+#   client - pulls that tar into an isolated netplay-data dir and plays
+#            on the borrowed copy; its own saves are never touched
+# Every failure path falls through to a normal launch ("fail-open").
+# Design: docs/superpowers/specs/2026-07-28-netplay-state-sync-design.md
+NETPLAY_PORT=19714
+NETPLAY_SRV=/tmp/nx_netplay
+NETPLAY_LOG=/tmp/nx_netplay.log
+NETPLAY_DEADLINE=90
+NX_HTTPD_PID=""
+
+# Read one key from one section of emu.cfg (empty when absent).
+nx_cfg_get() {
+    sed -n "/^\[$1\]/,/^\[/s/^$2 = *//p" "$EMU_CFG" | head -1
+}
+
+# Set one key in one section of emu.cfg, creating the section and/or the
+# key when missing. flycast drops keys left at their default when it
+# rewrites the file on quit, so [input] and server= are routinely absent
+# from a live cfg -- never assume either exists.
+nx_cfg_set() {
+    grep -q "^\[$1\]$" "$EMU_CFG" || printf '\n[%s]\n' "$1" >> "$EMU_CFG"
+    sed -n "/^\[$1\]/,/^\[/p" "$EMU_CFG" | grep -q "^$2 =" || \
+        sed -i "s/^\[$1\]\$/[$1]\n$2 =/" "$EMU_CFG"
+    sed -i "/^\[$1\]/,/^\[/s|^$2 =.*|$2 = $3|" "$EMU_CFG"
+}
+
+# wget with a watchdog: busybox wget has no timeout flag, so kill it
+# ourselves after $2 seconds. Prints fetched content (empty on failure).
+nx_fetch() {
+    # Each discovery pass runs a dozen-plus nx_fetch calls CONCURRENTLY,
+    # and in POSIX sh `$$` keeps the PARENT shell's pid inside a subshell
+    # -- so a pid-derived name is the SAME file in every probe. Measured
+    # on-device: 16 concurrent probes against a network with exactly one
+    # real peer returned ZERO hits, because one probe's trailing `rm -f`
+    # deleted the payload another had just downloaded; the same race also
+    # made a dead host report a live host's payload and win the `ls |
+    # sort | head -1` selection. Both present as "stuck looking for
+    # player 2", and this is the other half of the first pair test's
+    # failure: fixing it ALONE would still have been swamped by the ~250
+    # concurrent probes the un-deduplicated neighbour list produced (see
+    # nx_find_peer). Both fixes are required.
+    #
+    # The name must be unique per invocation. mktemp is at
+    # /bin/mktemp on both devices; the fallback derives uniqueness from
+    # the URL, which is likewise distinct for every concurrent probe.
+    NXF_OUT=$(mktemp /tmp/nx_netplay_fetch.XXXXXX 2>/dev/null)
+    if [ -z "$NXF_OUT" ]; then
+        NXF_OUT=/tmp/nx_netplay_fetch.$(printf '%s' "$1" | tr -c 'a-zA-Z0-9' '_')
+        rm -f "$NXF_OUT"
+    fi
+    wget -q -O "$NXF_OUT" "$1" 2>/dev/null &
+    NXF_PID=$!
+    NXF_T=0
+    while [ "$NXF_T" -lt "$2" ]; do
+        kill -0 "$NXF_PID" 2>/dev/null || break
+        # Abort promptly on cancel: without this a press during the
+        # client's up-to-30s tar download would sit unnoticed until the
+        # download finished. Callers already treat an empty result as a
+        # failed fetch.
+        nx_cancelled && break
+        sleep 1
+        NXF_T=$((NXF_T+1))
+    done
+    kill "$NXF_PID" 2>/dev/null
+    wait "$NXF_PID" 2>/dev/null
+    cat "$NXF_OUT" 2>/dev/null
+    rm -f "$NXF_OUT"
+}
+
+# --- status display -----------------------------------------------------
+# Drives show2.elf (already shipped in $SYSTEM_PATH/bin) in daemon mode so
+# the long discovery phase is not a silent black screen. show2 renders via
+# SDL2/DRM -- /dev/fb0 is NOT the display path on these devices, so a
+# framebuffer-writing helper would draw nothing. Every call here is a
+# guarded no-op when show2.elf is missing or its daemon died: discovery and
+# launch must never block or fail because of the UI.
+NX_UI_FIFO=/tmp/show2.fifo
+NX_UI_ON=""
+
+NX_CANCEL_FLAG=/tmp/nx_netplay_cancel
+NX_CANCEL_BTN=00          # physical B. Measured on a Brick 2026-07-29:
+                          # five presses, all "01 00 01 00" (value 0001,
+                          # type 01, number 00). Agrees with this pak's own
+                          # SDL_Xbox 360 Controller.cfg (bind0 = 0:btn_b).
+NX_CANCEL_PID=""
+NX_CANCELLED=""
+
+nx_ui_start() {
+    # Resolved via PATH ($SYSTEM_PATH/bin), exactly like this script's own
+    # bare sleepmon.elf / syncsettings.elf / taskset calls. Do NOT build a
+    # $SDCARD_PATH/.system/<platform>/bin path here: that differs per device
+    # and this block must stay byte-identical across both launch.sh files.
+    command -v show2.elf >/dev/null 2>&1 || return 0
+    rm -f "$NX_UI_FIFO"
+    # show2 needs libSDL2 from $SDCARD_PATH/.system/<platform>/lib, which
+    # launch.sh already put on LD_LIBRARY_PATH above; without it show2
+    # aborts with "libSDL2-2.0.so.0: cannot open shared object file".
+    # --image is mandatory but we have no netplay artwork; /dev/null is the
+    # repo's existing "no logo" idiom (see PortMaster's progressor).
+    # --progress=-1 selects show2's indeterminate marquee (show2.cpp:424),
+    # which is what the install boot.sh uses for exactly this kind of
+    # unknown-length wait -- an empty 0% bar would just look stalled.
+    if [ -n "$2" ]; then
+        show2.elf --mode=daemon --image=/dev/null --bgcolor=0x000000 \
+            --progress=-1 --text="$1" --hint="$2" >/dev/null 2>&1 &
+    else
+        show2.elf --mode=daemon --image=/dev/null --bgcolor=0x000000 \
+            --progress=-1 --text="$1" >/dev/null 2>&1 &
+    fi
+    NX_UI_ON=$!
+    # Daemon needs ~3-4s (SDL2 + DRM init) before it paints; do not wait
+    # for it here -- the network work below overlaps that cost.
+}
+
+# nx_ui "<message>" [progress 0-100]
+# Opening a FIFO for writing BLOCKS until a reader attaches, so a daemon
+# that died while leaving its FIFO node behind would hang the launch
+# forever on the next status update -- the exact failure this feature
+# exists to prevent. Two defences: skip when the daemon PID is gone, and
+# do the write in a background subshell so even a lost race can only
+# strand that subshell, never the script.
+nx_ui() {
+    [ -n "$NX_UI_ON" ] || return 0
+    kill -0 "$NX_UI_ON" 2>/dev/null || return 0
+    # show2 creates the FIFO only after its SDL2/DRM init: mkfifo is the
+    # first statement of runDaemonMode(), which runs after initialize()
+    # returns (~3-4s). A plain [ -p ] test here would therefore DROP every
+    # early message -- and those are the ones that matter, because the next
+    # update can be up to NETPLAY_DEADLINE seconds later. So wait for the
+    # node, but do it INSIDE the background subshell so the script itself
+    # never stalls. Ordering between messages queued during that init
+    # window is not guaranteed; they all land within a second of each
+    # other and only the last is visible, which is acceptable here.
+    ( NXU_T=0
+      while [ ! -p "$NX_UI_FIFO" ] && [ "$NXU_T" -lt 10 ]; do
+          kill -0 "$NX_UI_ON" 2>/dev/null || exit 0
+          sleep 1
+          NXU_T=$((NXU_T+1))
+      done
+      [ -p "$NX_UI_FIFO" ] || exit 0
+      printf 'TEXT:%s\n' "$1" > "$NX_UI_FIFO" 2>/dev/null
+      [ -n "$2" ] && printf 'PROGRESS:%s\n' "$2" > "$NX_UI_FIFO" 2>/dev/null
+      : ) &
+    return 0
+}
+
+nx_ui_stop() {
+    [ -n "$NX_UI_ON" ] || return 0
+    # Same blocking hazard as nx_ui, and worse here: this is the LAST
+    # statement before flycast launches, so a dead daemon that left its
+    # FIFO node behind would hang the launch at the finish line. Guard on
+    # liveness and background the write. killall is the real cleanup --
+    # it cannot block -- and the QUIT is only the graceful path.
+    if kill -0 "$NX_UI_ON" 2>/dev/null && [ -p "$NX_UI_FIFO" ]; then
+        ( printf 'QUIT\n' > "$NX_UI_FIFO" 2>/dev/null ) &
+    fi
+    # Belt-and-braces: nothing may hold the display against flycast.
+    # MUST be -9. Measured on a Brick 2026-07-29: after a plain SIGTERM the
+    # daemon was still alive 6 s later; SIGKILL ended it instantly. show2
+    # installs a handler for SIGINT only (show2.cpp:623) and SDL_Init traps
+    # SIGTERM into an SDL_QUIT event that show2 never pumps (it has no
+    # SDL_PollEvent at all), so SIGTERM is swallowed. MinUI.pak's own
+    # launch.sh:228 has always used -9 on this same binary.
+    killall -9 show2.elf 2>/dev/null
+    # Leave no stale node for the next launch to trip over.
+    rm -f "$NX_UI_FIFO" 2>/dev/null
+    NX_UI_ON=""
+    return 0
+}
+
+# --- cancel (press B to skip netplay) ----------------------------------
+# True once the user has asked to skip netplay.
+nx_cancelled() { [ -f "$NX_CANCEL_FLAG" ]; }
+
+# Watch the gamepad for a B press and drop a flag file.
+#
+# js0 delivers 8-byte events: u32 time, s16 value, u8 type, u8 number. A
+# real press is type 01 with a non-zero value; opening the device emits an
+# init burst (type 81/82, value 0) and releases carry value 0, so neither
+# can trigger a cancel, and stick movement (type 02) cannot either.
+#
+# Two shapes were tried on-device and BOTH failed; do not "simplify" back
+# to either:
+#   dd if=js0 | hexdump | while read   -- hexdump BLOCK-BUFFERS to a pipe,
+#     so presses sit unseen until ~4KB (~170 events) accumulates. A 45s
+#     capture recorded zero presses while buttons were being pressed.
+#   dd if=js0 count=1 inside a loop    -- re-opens the device every pass,
+#     replaying the init burst each time, and spins.
+# What works: open ONCE on fd 3, then one short-lived dd/hexdump per event
+# so hexdump exits (and therefore flushes) every time. Verified: presses
+# appear immediately and the loop blocks without spinning when idle.
+#
+# od is not on this firmware; hexdump is. Backgrounded so it can never
+# delay the launch. If js0 is unreadable the subshell exits at once and
+# cancel is simply unavailable -- every other path is unchanged.
+nx_cancel_arm() {
+    rm -f "$NX_CANCEL_FLAG"
+    [ -r /dev/input/js0 ] || return 0
+    (
+        exec 3< /dev/input/js0 || exit 0
+        while :; do
+            NXB_EV=$(dd bs=8 count=1 <&3 2>/dev/null | hexdump -v -e '8/1 "%02x " "\n"')
+            [ -n "$NXB_EV" ] || exit 0
+            set -- $NXB_EV
+            [ "$7" = "01" ] || continue
+            [ "$8" = "$NX_CANCEL_BTN" ] || continue
+            [ "$5$6" = "0000" ] && continue
+            : > "$NX_CANCEL_FLAG"
+            exit 0
+        done
+    ) &
+    NX_CANCEL_PID=$!
+    return 0
+}
+
+# Stop watching.
+#
+# Killing the subshell does NOT reap its children: the blocked dd, the
+# command-substitution child and hexdump each keep js0 open. That leak is
+# deliberately accepted rather than swept, and the reasoning is worth
+# keeping because both obvious sweeps are wrong here:
+#
+#   - Matching /proc/<pid>/cmdline cannot work. The device is opened with
+#     `exec 3< /dev/input/js0` and read with `dd bs=8 count=1 <&3`, so the
+#     path is a redirection, never an argument -- busybox ps shows the dd
+#     as "dd bs 8 count 1". Verified on-device: an argv sweep finds none of
+#     the holders.
+#   - Matching open descriptors (readlink /proc/<pid>/fd/*) DOES find them
+#     all -- also verified on-device -- but "kill whatever holds js0" is
+#     dangerous: keymon.elf opens input devices and runs throughout the
+#     game, and killing the launcher is known to power this device off.
+#     A cleanup that can kill the launcher is not worth a leak that clears
+#     itself.
+#
+# And it does clear itself: dd was started with count=1, so the first
+# controller event after flycast starts makes it read one event and exit,
+# hexdump then sees EOF, and the substitution child follows. joydev gives
+# each opener an independent event buffer, so nothing is taken from
+# flycast in the meantime.
+nx_cancel_disarm() {
+    [ -n "$NX_CANCEL_PID" ] && kill "$NX_CANCEL_PID" 2>/dev/null
+    NX_CANCEL_PID=""
+    rm -f "$NX_CANCEL_FLAG"
+    return 0
+}
+
+# Serve $NETPLAY_SRV on 19714 with whatever this firmware provides:
+# busybox httpd (tg5040) or python3 http.server (tg5050, whose busybox
+# 1.35 ships no httpd applet). Neither present -> no server, fail open.
+# httpd runs without -v, so there is no request log at all: $NETPLAY_LOG
+# only ever holds the server's own stdout/stderr (empty on tg5040). It
+# still lives OUTSIDE the serve dir so it is never itself served.
+# Must run in the parent shell, never inside $( ) -- NX_HTTPD_PID has to
+# survive for the cleanup block after wait $EMU_PID.
+nx_serve_start() {
+    # The pidfile is only removed on a clean exit, so a power-off or a
+    # hybrid-sleep leaves a stale one behind and the pid it names may have
+    # been recycled onto an unrelated process by the next launch. Blind
+    # SIGTERM to a recycled pid is a genuinely bad outcome on this device
+    # family, so confirm the pid is actually one of our servers before
+    # signalling it: /proc/<pid>/comm reads "httpd" or "python3" (the
+    # python path execs, so the subshell is replaced and comm is the
+    # interpreter, not sh). The pidfile goes either way -- a pid we
+    # decline to kill is not ours to keep tracking.
+    #
+    # BOTH stages are needed; the digits test alone is not enough. It
+    # accepts "0", and `kill 0` signals EVERY process in our process
+    # group. That is unreachable only because /proc/0/comm does not
+    # exist, so the comm test rejects it -- do not drop that test.
+    if [ -f /tmp/nx_netplay.pid ]; then
+        NXS_OLD=$(cat /tmp/nx_netplay.pid 2>/dev/null)
+        case "$NXS_OLD" in
+            ""|*[!0-9]*) ;;
+            *)
+                # A zero pid passes the all-digits test above, and
+                # `kill 0` signals EVERY process in this script's process
+                # group -- on this device family that reaches the
+                # launcher, and killing the launcher powers the unit off.
+                # /proc/0/comm not existing does block it today, but a
+                # guard against that blast radius should not rest on one
+                # accident. Test arithmetically rather than matching a
+                # literal 0: "00" is also zero and slips past a pattern.
+                if [ "$NXS_OLD" -gt 0 ]; then
+                    case "$(cat "/proc/$NXS_OLD/comm" 2>/dev/null)" in
+                        httpd|python3) kill "$NXS_OLD" 2>/dev/null ;;
+                    esac
+                fi
+                ;;
+        esac
+        rm -f /tmp/nx_netplay.pid
+    fi
+    if command -v httpd >/dev/null 2>&1; then
+        httpd -f -p "$NETPLAY_PORT" -h "$NETPLAY_SRV" > "$NETPLAY_LOG" 2>&1 &
+        NX_HTTPD_PID=$!
+    elif command -v python3 >/dev/null 2>&1; then
+        ( cd "$NETPLAY_SRV" && exec python3 -u -m http.server "$NETPLAY_PORT" ) \
+            > "$NETPLAY_LOG" 2>&1 &
+        NX_HTTPD_PID=$!
+    fi
+    [ -n "$NX_HTTPD_PID" ] && echo "$NX_HTTPD_PID" > /tmp/nx_netplay.pid
+}
+
+# True when $1 serves a netplay-info for this ROM in role $2. The role
+# line is what stops two hosts (or two clients) from pairing, and the
+# ROM line stops cross-game pairing.
+nx_probe() {
+    NXI=$(nx_fetch "http://$1:$NETPLAY_PORT/netplay-info" 3)
+    [ "$(printf '%s\n' "$NXI" | sed -n 1p)" = "$EMU_OVERLAY_GAME" ] && \
+    [ "$(printf '%s\n' "$NXI" | sed -n 2p)" = "$2" ]
+}
+
+# Print the IP of a peer in role $1, or nothing. Tries the stored server=
+# first, but only when it is in our current /24 -- after a relocation the
+# stored address belongs to the old network and can never answer, so
+# probing it just burns ~3s. Then ping-sweeps the /24 and probes every
+# neighbour CONCURRENTLY: serial probes cost >=1s each (nx_fetch's poll
+# floor), so a LAN with N reachable hosts used to cost ~N seconds per
+# pass. Runs inside $( ) -- it must not set anything the caller needs.
+nx_find_peer() {
+    NXP_WANT=$1
+    NXP_MYIP=$(ip -4 addr show wlan0 2>/dev/null | \
+        sed -n 's|.*inet \([0-9.]*\)/24 .*|\1|p' | head -1)
+    NXP_NET=${NXP_MYIP%.*}
+    NXP_STORED=$(nx_cfg_get network server)
+    if [ -n "$NXP_STORED" ] && [ -n "$NXP_NET" ] && \
+       [ "${NXP_STORED%.*}" = "$NXP_NET" ] && \
+       nx_probe "$NXP_STORED" "$NXP_WANT"; then
+        echo "$NXP_STORED"
+        return
+    fi
+    NXP_HITS=/tmp/nx_netplay_hits
+    NXP_END=$(( $(date +%s) + NETPLAY_DEADLINE ))
+    while [ "$(date +%s)" -lt "$NXP_END" ]; do
+        nx_cancelled && return
+        if [ -n "$NXP_NET" ]; then
+            NXP_I=1
+            while [ "$NXP_I" -le 254 ]; do
+                ping -c1 -W1 "$NXP_NET.$NXP_I" >/dev/null 2>&1 &
+                NXP_I=$((NXP_I+1))
+            done
+            sleep 3
+        else
+            # No /24 sweep to pace the loop; without this an empty
+            # neighbour table would spin the deadline loop hot.
+            sleep 1
+        fi
+        rm -rf "$NXP_HITS"
+        mkdir -p "$NXP_HITS"
+        # A /24 sweep leaves an ARP entry for EVERY address it probed, and
+        # a router that answers ARP for unused addresses turns that into
+        # hundreds of entries sharing a handful of MACs. Probing all of
+        # them spawns hundreds of concurrent wgets on a 4-core handheld,
+        # none finish inside the collect window below, and the peer is
+        # never found -- one half of how the first real pair test failed.
+        # The other half is nx_fetch's shared temp file (see there): dedup
+        # ALONE cannot fix discovery, because that race destroys the
+        # result at any concurrency.
+        #
+        # Deduplicate by MAC: one candidate per physical device. Measured
+        # on-device, as one dataset through the two filter stages:
+        #   raw `ip neigh`                     259 lines, ~19 MACs
+        #   after the IPv4 + valid-lladdr sed  222 lines,  16 MACs
+        # so 16 candidates survive, the real peer among them -- phantoms
+        # share the router's MAC, real devices each keep their own.
+        #
+        # awk rather than `sort -u -k1,1` because a busybox built without
+        # CONFIG_FEATURE_SORT_BIG has no `-k` at all; where `-k` exists,
+        # `sort -u` does honour it (verified on tg5050).
+        #
+        # Both sed anchors are load-bearing, and they earn their keep on
+        # different inputs:
+        #   ^\([0-9.]*\)   excludes IPv6, which is checked before the
+        #     lladdr group is even consulted. It matters: an IPv6 neighbour
+        #     sharing the PEER's MAC would otherwise claim that MAC's
+        #     seen[] slot and hide the peer behind an unprobeable candidate.
+        #   \{17\}         excludes malformed lladdr values. Without it
+        #     "192.168.1.20 dev wlan0 lladdr INCOMPLETE" yields an empty
+        #     MAC key and awk then prints an empty candidate.
+        for NXP_IP in $(ip neigh 2>/dev/null | \
+                sed -n 's/^\([0-9.]*\) .*lladdr \([0-9a-f:]\{17\}\).*/\2 \1/p' | \
+                awk '!seen[$1]++ {print $2}'); do
+            nx_cancelled && return
+            [ "$NXP_IP" = "$NXP_MYIP" ] && continue
+            ( nx_probe "$NXP_IP" "$NXP_WANT" && : > "$NXP_HITS/$NXP_IP" ) &
+        done
+        # One probe's worth of wall clock rather than N probes' -- but note
+        # this function runs inside $( ), and a command substitution does
+        # not return until every background child it spawned has exited
+        # (they inherit the capture pipe). So the caller actually waits
+        # max(this sleep, slowest straggler probe). That is bounded: each
+        # nx_probe goes through nx_fetch's 3s watchdog. Measure the
+        # substitution, not this sleep, when timing a pass.
+        sleep 4
+        # Sorted so a re-run on an unchanged LAN picks the same peer.
+        NXP_FOUND=$(ls "$NXP_HITS" 2>/dev/null | sort | head -1)
+        rm -rf "$NXP_HITS"
+        if [ -n "$NXP_FOUND" ]; then
+            echo "$NXP_FOUND"
+            return
+        fi
+    done
+}
+
+nx_netplay_host() {
+    NXH_DATA="$USERDATA_DIR/data/flycast"
+    # Deliberately no progress value. This call and the -1 one below are
+    # both backgrounded and may still be waiting on show2's FIFO during
+    # its ~3-4s init, so their arrival order is not guaranteed. A numeric
+    # PROGRESS: landing after the -1 would cancel the marquee and freeze
+    # the bar for the whole discovery wait. Sending none means the only
+    # progress the daemon can see before that wait is -1, which makes this
+    # path deterministic and matches the client path.
+    nx_ui "Preparing saves..."
+    # One-deep crash insurance: the REAL card is live during a netplay
+    # session, so snapshot it first (~384 KB, overwritten each session).
+    mkdir -p "$USERDATA_DIR/netplay-backup"
+    cp -f "$NXH_DATA"/vmu_save_*.bin "$NXH_DATA/dc_nvmem.bin" \
+        "$USERDATA_DIR/netplay-backup/" 2>/dev/null
+    rm -rf "$NETPLAY_SRV"
+    mkdir -p "$NETPLAY_SRV"
+    printf '%s\nhost\n' "$EMU_OVERLAY_GAME" > "$NETPLAY_SRV/netplay-info"
+    (cd "$NXH_DATA" 2>/dev/null && \
+        tar cf "$NETPLAY_SRV/netplay-sync.tar" vmu_save_*.bin dc_nvmem.bin 2>/dev/null)
+    nx_serve_start
+    nx_cancelled && { NX_CANCELLED=1; return 0; }
+    # Computed here in the parent shell: nx_find_peer's own copy lives in
+    # a $( ) subshell and would always read back empty at this point.
+    NXH_NET=$(ip -4 addr show wlan0 2>/dev/null | \
+        sed -n 's|.*inet \([0-9.]*\)/24 .*|\1|p' | head -1)
+    if [ -n "$NXH_NET" ]; then NXH_WHERE="${NXH_NET%.*}.x"; else NXH_WHERE="the network"; fi
+    nx_ui "Looking for player 2 on $NXH_WHERE..." -1
+    NXH_PEER=$(nx_find_peer client)
+    if [ -n "$NXH_PEER" ]; then
+        nx_cfg_set network server "$NXH_PEER"
+        nx_ui "Player 2 found at $NXH_PEER" 90
+    else
+        nx_ui "No player 2 found - starting anyway" 100
+    fi
+    # No peer found: fail open on whatever server= already holds.
+}
+
+nx_netplay_client() {
+    NXC_NPDATA="$USERDATA_DIR/netplay-data/flycast"
+    mkdir -p "$NXC_NPDATA"
+    nx_ui "Looking for the host..." -1
+    # The client serves only its identity -- never any save data.
+    rm -rf "$NETPLAY_SRV"
+    mkdir -p "$NETPLAY_SRV"
+    printf '%s\nclient\n' "$EMU_OVERLAY_GAME" > "$NETPLAY_SRV/netplay-info"
+    nx_serve_start
+    nx_cancelled && { NX_CANCELLED=1; return 0; }
+    NXC_PEER=$(nx_find_peer host)
+    if [ -n "$NXC_PEER" ]; then
+        nx_cfg_set network server "$NXC_PEER"
+        nx_ui "Host found at $NXC_PEER - copying saves..." 60
+        nx_fetch "http://$NXC_PEER:$NETPLAY_PORT/netplay-sync.tar" 30 > /tmp/nx_netplay_sync.tar
+        # Tar-slip guard: the peer is discovered, not authenticated, and
+        # this script runs as root, so accept an archive only when ALL of
+        # these hold -- it lists at least one entry (a non-tar payload
+        # lists nothing, which would pass every negated test vacuously);
+        # every name is a bare expected filename (no slashes, no "..",
+        # no absolute paths); every mode column is "-"; and no entry is a
+        # link. The explicit link test is NOT redundant with the mode
+        # column: busybox tar prints a HARDLINK as "-" (only GNU tar uses
+        # "h"), so on this firmware the mode column alone would accept
+        # one. Both link kinds render their target as "name -> target".
+        # Without this a link named vmu_save_A1.bin could land in
+        # netplay-data and flycast would write VMU data through it.
+        if [ -s /tmp/nx_netplay_sync.tar ] && \
+           tar tf /tmp/nx_netplay_sync.tar 2>/dev/null | grep -q . && \
+           ! tar tf /tmp/nx_netplay_sync.tar 2>/dev/null | \
+             grep -qv '^vmu_save_[A-D][12]\.bin$\|^dc_nvmem\.bin$' && \
+           ! tar tvf /tmp/nx_netplay_sync.tar 2>/dev/null | \
+             grep -qv '^-' && \
+           ! tar tvf /tmp/nx_netplay_sync.tar 2>/dev/null | \
+             grep -q ' -> '; then
+            (cd "$NXC_NPDATA" && tar xf /tmp/nx_netplay_sync.tar 2>/dev/null)
+        fi
+        rm -f /tmp/nx_netplay_sync.tar
+    fi
+    [ -n "$NXC_PEER" ] || nx_ui "No host found - starting anyway" 100
+    # Borrowed-copy isolation: play on the synced copy; the client's real
+    # saves under data/flycast are never read or written during netplay.
+    #
+    # Cancelled means "play this game normally", so do NOT redirect saves
+    # to the borrowed netplay-data copy -- with GGPO off there is nothing
+    # to isolate, and the user would otherwise be playing single-player on
+    # the host's VMU instead of their own. (Their real saves are untouched
+    # either way; this is about which set the session actually uses.)
+    if nx_cancelled; then
+        NX_CANCELLED=1
+    else
+        export XDG_DATA_HOME="$USERDATA_DIR/netplay-data"
+    fi
+}
+
+if [ "$(nx_cfg_get network GGPO)" = "yes" ]; then
+    nx_ui_start "Starting..." "B = skip netplay"
+    nx_cancel_arm
+    # Plug a controller into DC port B. GGPO always drives port B as
+    # player 2 -- the REMOTE player on the host, the LOCAL player on the
+    # client (ggpo.cpp:500,569 make the local player localPlayerNum + 1;
+    # ggpo.cpp:643-650 writes inputState[player] straight to the maple
+    # port index) -- so BOTH machines need a pad there; that the client's
+    # own Start did nothing is exactly this. flycast leaves device2 =
+    # MDT_None (10) by default (option.cpp:197-201), so with port B empty
+    # those inputs reach no maple device and MvC2's VS mode stays greyed
+    # out. Both peers must carry the identical value or the emulated
+    # machines differ and desync -- which is why this is set here on both
+    # sides, not by hand.
+    nx_cfg_set input device2 0
+    # Close flycast's router port punching. EnableUPnP defaults to TRUE
+    # (option.cpp:172), and ggpo.cpp:801-804 runs miniupnp.Init() +
+    # AddPortMapping(19713/UDP) BEFORE the ActAsServer branch, so BOTH
+    # roles punch a mapping with an 86400 s lease (miniupnp.cpp). The
+    # seeded EnableUPnP = no in the default*.cfg files only reaches FRESH
+    # installs (it is gated behind .initialized), so no existing device
+    # ever gets it -- setting it here closes it everywhere. No
+    # restore-when-off branch is needed: the value is only consulted on
+    # the GGPO path.
+    nx_cfg_set network EnableUPnP no
+    if [ "$(nx_cfg_get network ActAsServer)" = "yes" ]; then
+        nx_netplay_host
+    else
+        nx_netplay_client
+    fi
+    if nx_cancelled; then
+        NX_CANCELLED=1
+        # nx_serve_start has already run in both role functions by the
+        # time a cancel is noticed, and on the host path the tar holds
+        # real VMU + dc_nvmem data. Without this the server keeps
+        # offering it on TCP 19714 until `wait $EMU_PID` returns -- i.e.
+        # for the whole session the user asked to spend NOT doing
+        # netplay. Tear it down here rather than in each role function.
+        if [ -n "$NX_HTTPD_PID" ]; then
+            kill "$NX_HTTPD_PID" 2>/dev/null
+            NX_HTTPD_PID=""
+        fi
+        rm -f /tmp/nx_netplay.pid
+        rm -rf "$NETPLAY_SRV"
+        nx_ui "Skipped - starting game..."
+        # nx_ui only QUEUES its write in a background subshell, and
+        # nx_ui_stop kills show2 immediately below, so without this pause
+        # the confirmation is never drawn -- pressing B would look exactly
+        # like nothing happening until flycast appears. One second is
+        # enough for the subshell to be scheduled, open the FIFO and for
+        # show2 to render a frame (it runs at 60 fps). This cost is paid
+        # ONLY on the cancel path, never on a normal launch.
+        sleep 1
+    fi
+    # Disarming deletes the flag file, so it MUST stay after the test
+    # above -- do not reorder these two.
+    nx_cancel_disarm
+    nx_ui_stop
+else
+    # Netplay off: unplug port B again so single-player sessions see the
+    # stock one-pad Dreamcast. It rewrites the key only when it currently
+    # holds this block's own value (0), so a user who deliberately
+    # configured another port-B device is not clobbered -- but a 0 set
+    # through flycast's own Controls UI for local two-pad play is
+    # indistinguishable from ours and does get reverted here.
+    [ "$(nx_cfg_get input device2)" = "0" ] && nx_cfg_set input device2 10
+fi
+# --- end netplay -------------------------------------------------------
+
 cd "$PAK_DIR"
-./flycast "$ROM" &> "$LOGS_PATH/$EMU_TAG.txt" &
+if [ -n "$NX_CANCELLED" ]; then
+    # Virtual config: flycast's get_entry() prefers virtual values and
+    # ConfigFile::save() never writes them, so this disables netplay for
+    # THIS RUN ONLY and emu.cfg is left byte-identical.
+    ./flycast -config network:GGPO=no "$ROM" &> "$LOGS_PATH/$EMU_TAG.txt" &
+else
+    ./flycast "$ROM" &> "$LOGS_PATH/$EMU_TAG.txt" &
+fi
 EMU_PID=$!
 
 # Thread pinning (dual cluster). Evidence-based (see task-11 report): tg5040
@@ -179,4 +766,8 @@ kill -0 "$EMU_PID" 2>/dev/null && pin_threads
 wait $EMU_PID
 killall sleepmon.elf 2>/dev/null || true
 kill $SYNC_PID 2>/dev/null || true
+if [ -n "$NX_HTTPD_PID" ]; then
+    kill "$NX_HTTPD_PID" 2>/dev/null
+    rm -f /tmp/nx_netplay.pid
+fi
 echo 0 > /sys/class/speaker/mute 2>/dev/null || true

--- a/skeleton/EXTRAS/Emus/tg5050/DC.pak/launch.sh
+++ b/skeleton/EXTRAS/Emus/tg5050/DC.pak/launch.sh
@@ -15,18 +15,8 @@ echo 1992000 >/sys/devices/system/cpu/cpu4/cpufreq/scaling_min_freq
 # GPU: lock to performance for flycast rendering
 echo performance >/sys/devices/platform/soc@3000000/1800000.gpu/devfreq/1800000.gpu/governor 2>/dev/null
 
-# User data (config per device, VMU + save states shared across devices)
-USERDATA_DIR="$SHARED_USERDATA_PATH/DC-flycast"
-DEVICE_CONFIG_DIR="$USERDATA_DIR/config/tg5050"
-DEVICE_DEFAULT_CFG="$PAK_DIR/default.cfg"
-mkdir -p "$DEVICE_CONFIG_DIR/flycast/mappings" "$USERDATA_DIR/data/flycast"
-
-# First run: copy device-specific defaults
-if [ ! -f "$DEVICE_CONFIG_DIR/.initialized" ]; then
-    cp "$DEVICE_DEFAULT_CFG" "$DEVICE_CONFIG_DIR/flycast/emu.cfg"
-    touch "$DEVICE_CONFIG_DIR/.initialized"
-fi
-EMU_CFG="$DEVICE_CONFIG_DIR/flycast/emu.cfg"
+# Config-dir resolution + emu.cfg seeding shared with options.sh
+. "$PAK_DIR/nx_paths.sh"
 
 # Install the curated controller mapping if not already present. Deliberately
 # NOT gated by .initialized: that marker only tracks the emu.cfg seed, so an
@@ -75,6 +65,7 @@ MINUI_DIR="$SHARED_USERDATA_PATH/.minui/$EMU_TAG"
 mkdir -p "$MINUI_DIR"
 export EMU_OVERLAY_SCREENSHOT_DIR="$MINUI_DIR"
 export EMU_OVERLAY_ROMFILE="$(basename "$ROM")"
+export EMU_OVERLAY_HIDE_OPTIONS=1  # options moved to the pre-launch editor (options.sh)
 
 # Mute speaker before launch to prevent audio pop, then unmute after init
 echo 1 > /sys/class/speaker/mute 2>/dev/null || true
@@ -114,8 +105,10 @@ export NX_AUDIO_RATE=$(nx_pick_audio_rate 44100)
 # VMU/flash read-only on TCP 18731; the client pulls into netplay-data).
 # Every netplay value below is passed as a VIRTUAL -config: flycast's
 # get_entry() prefers virtual values and ConfigFile::save() never writes
-# them, so emu.cfg is untouched by a netplay run. GGPODelay/DCNet remain
-# real overlay settings that flycast reads from emu.cfg itself.
+# them, so emu.cfg is untouched by a netplay run. GGPODelay remains a
+# real overlay setting that flycast reads from emu.cfg itself; DCNet is
+# forced off among the virtual values below, so its overlay/per-game
+# value only ever reaches a normal launch.
 # Design: docs/superpowers/specs/2026-07-29-netplay-prelaunch-wizard-design.md
 
 # Read one key from one section of emu.cfg (empty when absent).
@@ -202,15 +195,43 @@ if [ -f /tmp/netplay_launch ]; then
     # device2=0 plugs a pad into DC port B on BOTH sides (GGPO drives
     # port B as player 2 -- remote on the host, LOCAL on the client);
     # EnableUPnP=no stops ggpo.cpp:801-804 punching a router mapping.
-    NETPLAY_ARGS="-config network:GGPO=yes -config network:ActAsServer=$NX_AS_SERVER -config network:server=$NETPLAY_PEER_IP -config network:EnableUPnP=no -config input:device2=0"
+    # DCNet=no is forced: DCNet routes the emulated modem to an external
+    # cloud service, an input the GGPO lockstep never synchronizes, so a
+    # peer's modem traffic desyncs the session. A per-game or global
+    # DCNet=yes IS a repeated key here and NETPLAY_ARGS comes last, so it
+    # loses on a netplay launch and still applies to a normal one.
+    NETPLAY_ARGS="-config network:GGPO=yes -config network:ActAsServer=$NX_AS_SERVER -config network:server=$NETPLAY_PEER_IP -config network:EnableUPnP=no -config input:device2=0 -config network:DCNet=no"
 fi
 # --- end netplay -------------------------------------------------------
 
+# --- Per-game option overrides ------------------------------------------
+# Written by options.elf ("Emulator Options" in the game list's context
+# menu). Each entry becomes a VIRTUAL -config (never persisted by flycast),
+# so emu.cfg stays the device-global config and flycast's wholesale config
+# rewriting can never bake per-game values into it. Values are ints/bools
+# and never contain whitespace, so word-splitting GAME_ARGS is safe.
+# A malformed or unreadable file yields no args: the game still launches.
+GAME_ARGS=""
+NX_ROM_BASE="$(nx_rom_base "$ROM")"
+NX_GAME_CFG="$DEVICE_CONFIG_DIR/games/$NX_ROM_BASE.cfg"
+if [ -f "$NX_GAME_CFG" ]; then
+    GAME_ARGS=$(awk -F' = ' '
+        /^\[.*\]$/ { sec = substr($0, 2, length($0) - 2); next }
+        NF == 2 && sec != "" { printf "-config %s:%s=%s ", sec, $1, $2 }
+    ' "$NX_GAME_CFG" 2>/dev/null)
+fi
+# --- end per-game overrides ---------------------------------------------
+
 cd "$PAK_DIR"
-# $NETPLAY_ARGS is deliberately UNQUOTED: it is a word-split argument list
-# (-config pairs) whose values contain no whitespace, and it is empty on
-# every normal launch, where it word-splits to nothing at all.
-./flycast $NETPLAY_ARGS "$ROM" &> "$LOGS_PATH/$EMU_TAG.txt" &
+# $GAME_ARGS / $NETPLAY_ARGS are deliberately UNQUOTED: word-split argument
+# lists (-config pairs) whose values contain no whitespace, empty on normal
+# launches. NETPLAY_ARGS comes last so its network:* values win over any
+# per-game override on a netplay launch: flycast's LAST -config wins for a
+# repeated section:key -- ParseCommandLine() walks argv left-to-right
+# (core/cfg/cl.cpp) and every -config lands in cfgSetVirtual() ->
+# ConfigSection::set(), a plain std::map assignment that overwrites
+# (core/cfg/ini.cpp).
+./flycast $GAME_ARGS $NETPLAY_ARGS "$ROM" &> "$LOGS_PATH/$EMU_TAG.txt" &
 EMU_PID=$!
 
 # Thread pinning (dual cluster). Evidence-based (see task-11 report): tg5040

--- a/skeleton/EXTRAS/Emus/tg5050/DC.pak/netplay
+++ b/skeleton/EXTRAS/Emus/tg5050/DC.pak/netplay
@@ -1,0 +1,1 @@
+nextui marker: this pak supports "Y = Launch with Netplay" from the game list

--- a/skeleton/EXTRAS/Emus/tg5050/DC.pak/nx_paths.sh
+++ b/skeleton/EXTRAS/Emus/tg5050/DC.pak/nx_paths.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# Shared by launch.sh and options.sh (sourced, not executed): resolve the
+# per-device config dir and seed emu.cfg on first use, so options can be
+# edited before a game has ever launched without the two scripts drifting.
+# Expects PAK_DIR to be set by the sourcing script.
+
+# User data (config per device, VMU + save states shared across devices)
+USERDATA_DIR="$SHARED_USERDATA_PATH/DC-flycast"
+DEVICE_CONFIG_DIR="$USERDATA_DIR/config/tg5050"
+DEVICE_DEFAULT_CFG="$PAK_DIR/default.cfg"
+mkdir -p "$DEVICE_CONFIG_DIR/flycast/mappings" "$USERDATA_DIR/data/flycast"
+
+# First run: copy device-specific defaults
+if [ ! -f "$DEVICE_CONFIG_DIR/.initialized" ]; then
+    cp "$DEVICE_DEFAULT_CFG" "$DEVICE_CONFIG_DIR/flycast/emu.cfg"
+    touch "$DEVICE_CONFIG_DIR/.initialized"
+fi
+EMU_CFG="$DEVICE_CONFIG_DIR/flycast/emu.cfg"
+
+# Per-game override key. Multi-disc games live in a folder with a
+# folder-named .m3u (see BASE README); every disc of such a game maps to
+# ONE key -- the m3u/folder name -- mirroring how minarch normalizes
+# alt_name for its own per-game config (ma_game.c:110-136), except that
+# this pak's key convention drops the extension. Without this, the editor
+# (handed the .m3u by nextui) and launch.sh (handed a resolved first-disc
+# path by openRom) would write and read different override files.
+nx_rom_base() {
+    _dir="$(dirname "$1")"
+    _dirbase="${_dir##*/}"
+    if [ -f "$_dir/$_dirbase.m3u" ]; then
+        printf '%s' "$_dirbase"
+    else
+        _b="${1##*/}"
+        printf '%s' "${_b%.*}"
+    fi
+}

--- a/skeleton/EXTRAS/Emus/tg5050/DC.pak/options.sh
+++ b/skeleton/EXTRAS/Emus/tg5050/DC.pak/options.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# NAME: Dreamcast (Flycast)
+# Pre-launch options editor entry point. Its existence is also the capability
+# marker nextui probes for the "Emulator Options" context-menu entry (the
+# same pattern as the `netplay` marker file).
+# Usage: options.sh [rom-path]   (no arg: edit the device-global defaults)
+
+PAK_DIR="$(dirname "$0")"
+cd "$PAK_DIR"
+
+# Config-dir resolution + emu.cfg seeding shared with launch.sh
+. "$PAK_DIR/nx_paths.sh"
+
+JSON="$SDCARD_PATH/Emus/shared/flycast/overlay_settings.json"
+
+if [ -n "$1" ]; then
+    ROM="$1"
+    NX_ROM_BASE="$(nx_rom_base "$ROM")"
+    mkdir -p "$DEVICE_CONFIG_DIR/games"
+    options.elf --json "$JSON" --ini "$EMU_CFG" \
+        --override "$DEVICE_CONFIG_DIR/games/$NX_ROM_BASE.cfg" \
+        --game "$NX_ROM_BASE" 2> "$LOGS_PATH/emu-options.txt"
+else
+    options.elf --json "$JSON" --ini "$EMU_CFG" \
+        --game "Dreamcast (Flycast)" 2> "$LOGS_PATH/emu-options.txt"
+fi

--- a/skeleton/EXTRAS/Tools/tg5040/Emulator Settings.pak/launch.sh
+++ b/skeleton/EXTRAS/Tools/tg5040/Emulator Settings.pak/launch.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+cd "$(dirname "$0")"
+
+# Low fixed frequency for simple UI
+echo 600000 > /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq 2>/dev/null
+
+# …/Tools/<platform>/Emulator Settings.pak -> <platform>
+NX_PLATFORM="$(basename "$(dirname "$(pwd)")")"
+
+# Emulator paks opt in by shipping an options.sh (also the marker nextui
+# probes for the game list's "Emulator Options" context-menu entry).
+# Display name comes from its "# NAME:" line, falling back to the pak name.
+set --
+for opt in "$SDCARD_PATH/Emus/$NX_PLATFORM"/*.pak/options.sh; do
+    [ -f "$opt" ] || continue
+    name="$(sed -n 's/^# NAME: //p' "$opt" | head -1)"
+    [ -n "$name" ] || name="$(basename "$(dirname "$opt")" .pak)"
+    set -- "$@" --entry "$name" "$opt"
+done
+
+# Nothing to configure (no emulator pak ships options.sh on this card)
+[ $# -eq 0 ] && exit 0
+
+# Picker prints the chosen options.sh on stdout; empty means cancelled.
+CHOSEN="$(options.elf --pick "$@" 2> "$LOGS_PATH/emu-settings.txt")"
+[ -n "$CHOSEN" ] && exec "$CHOSEN"

--- a/skeleton/EXTRAS/Tools/tg5050/Emulator Settings.pak/launch.sh
+++ b/skeleton/EXTRAS/Tools/tg5050/Emulator Settings.pak/launch.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+cd "$(dirname "$0")"
+
+# Idle big core at minimum, little cores auto-scale via schedutil
+echo 408000 > /sys/devices/system/cpu/cpu4/cpufreq/scaling_max_freq 2>/dev/null
+
+# …/Tools/<platform>/Emulator Settings.pak -> <platform>
+NX_PLATFORM="$(basename "$(dirname "$(pwd)")")"
+
+# Emulator paks opt in by shipping an options.sh (also the marker nextui
+# probes for the game list's "Emulator Options" context-menu entry).
+# Display name comes from its "# NAME:" line, falling back to the pak name.
+set --
+for opt in "$SDCARD_PATH/Emus/$NX_PLATFORM"/*.pak/options.sh; do
+    [ -f "$opt" ] || continue
+    name="$(sed -n 's/^# NAME: //p' "$opt" | head -1)"
+    [ -n "$name" ] || name="$(basename "$(dirname "$opt")" .pak)"
+    set -- "$@" --entry "$name" "$opt"
+done
+
+# Nothing to configure (no emulator pak ships options.sh on this card)
+[ $# -eq 0 ] && exit 0
+
+# Picker prints the chosen options.sh on stdout; empty means cancelled.
+CHOSEN="$(options.elf --pick "$@" 2> "$LOGS_PATH/emu-settings.txt")"
+[ -n "$CHOSEN" ] && exec "$CHOSEN"

--- a/workspace/Makefile
+++ b/workspace/Makefile
@@ -59,6 +59,7 @@ endif
 	cd ./all/sync/ && make
 ifneq (,$(filter $(PLATFORM),tg5040 tg5050))
 	cd ./all/netplay-wizard/ && make
+	cd ./all/emu-options/ && make
 endif
 	cd ./all/scraper/ && make
 endif
@@ -111,5 +112,6 @@ endif
 	cd ./all/portmaster/ && make clean
 	cd ./all/sync/ && make clean
 	cd ./all/netplay-wizard/ && make clean
+	cd ./all/emu-options/ && make clean
 	cd ./all/scraper/ && make clean
 	cd ./$(PLATFORM) && make clean

--- a/workspace/Makefile
+++ b/workspace/Makefile
@@ -57,6 +57,9 @@ endif
 	cd ./all/mediaplayer/ && make
 	cd ./all/portmaster/ && make
 	cd ./all/sync/ && make
+ifneq (,$(filter $(PLATFORM),tg5040 tg5050))
+	cd ./all/netplay-wizard/ && make
+endif
 	cd ./all/scraper/ && make
 endif
 ifdef COMPILE_CORES
@@ -107,5 +110,6 @@ endif
 	cd ./all/mediaplayer/ && make clean
 	cd ./all/portmaster/ && make clean
 	cd ./all/sync/ && make clean
+	cd ./all/netplay-wizard/ && make clean
 	cd ./all/scraper/ && make clean
 	cd ./$(PLATFORM) && make clean

--- a/workspace/all/common/defines.h
+++ b/workspace/all/common/defines.h
@@ -38,6 +38,7 @@
 #define LAST_PATH "/tmp/last.txt" // transient
 #define CHANGE_DISC_PATH "/tmp/change_disc.txt"
 #define RESUME_SLOT_PATH "/tmp/resume_slot.txt"
+#define NETPLAY_LAUNCH_PATH "/tmp/netplay_launch"
 #define NOUI_PATH "/tmp/noui"
 #define EMULIST_CACHE_PATH "/tmp/emulist_cache.txt"
 #define ROMINDEX_CACHE_PATH "/tmp/romindex_cache.txt"

--- a/workspace/all/common/emu_overlay.c
+++ b/workspace/all/common/emu_overlay.c
@@ -38,7 +38,7 @@ static void build_main_menu(EmuOvl* ovl) {
 		n++;
 	}
 
-	if (ovl->config->section_count > 0) {
+	if (ovl->config->section_count > 0 && !ovl->hide_options) {
 		snprintf(ovl->main_items[n].label, sizeof(ovl->main_items[n].label), "Options");
 		ovl->main_items[n].type = EMU_OVL_MAIN_OPTIONS;
 		n++;
@@ -234,6 +234,10 @@ int emu_ovl_init(EmuOvl* ovl, EmuOvlConfig* cfg, EmuOvlRenderBackend* render,
 		ovl->items_per_page = 5;
 	else
 		ovl->items_per_page = 8;
+
+	// Options are edited pre-launch on some platforms; hide the in-game entry
+	const char* hide_opts = getenv("EMU_OVERLAY_HIDE_OPTIONS");
+	ovl->hide_options = hide_opts && strcmp(hide_opts, "1") == 0;
 
 	build_main_menu(ovl);
 

--- a/workspace/all/common/emu_overlay.h
+++ b/workspace/all/common/emu_overlay.h
@@ -84,6 +84,8 @@ typedef struct {
 	char screenshot_dir[512];		   // e.g. /mnt/SDCARD/.userdata/shared/.minui/N64
 	char rom_file[256];				   // e.g. "Super Mario 64.z64"
 	int slot_icons[EMU_OVL_MAX_SLOTS]; // icon_id per slot, -1 = none
+
+	bool hide_options; // EMU_OVERLAY_HIDE_OPTIONS=1: options edited pre-launch instead
 } EmuOvl;
 
 int emu_ovl_init(EmuOvl* ovl, EmuOvlConfig* cfg, EmuOvlRenderBackend* render,

--- a/workspace/all/common/emu_overlay_cfg.c
+++ b/workspace/all/common/emu_overlay_cfg.c
@@ -286,12 +286,83 @@ static int parse_ini_int(const char* val) {
 	return atoi(val);
 }
 
+// Convert an INI string to this item's internal int representation. Sole
+// owner of the per-type dispatch: emu_ovl_cfg_read_ini and the public
+// emu_ovl_cfg_parse_value both route through here so the overlay, the
+// pre-launch options editor and launch.sh can never disagree about what a
+// stored value means.
+static int parse_item_value(const EmuOvlItem* item, const char* val) {
+	switch (item->type) {
+	case EMU_OVL_TYPE_BOOL:
+		return parse_ini_bool(val);
+	case EMU_OVL_TYPE_CYCLE:
+	case EMU_OVL_TYPE_INT:
+		if (item->float_scale > 0)
+			return (int)(atof(val) * item->float_scale + 0.5);
+		return parse_ini_int(val);
+	default:
+		return parse_ini_int(val);
+	}
+}
+
+// Whole string is a well-formed decimal/float number (no leading sign-only,
+// no trailing junk). Leading whitespace is tolerated by strtod; callers are
+// expected to have trimmed already.
+static bool str_is_number(const char* s) {
+	if (!s || !*s)
+		return false;
+	char* end = NULL;
+	strtod(s, &end);
+	return end != NULL && end != s && *end == '\0';
+}
+
 // Get the effective INI section name for a config section.
 // Uses per-section ini_section if set, otherwise falls back to global config_section.
 static const char* get_ini_section(const EmuOvlConfig* cfg, const EmuOvlSection* sec) {
 	if (sec->ini_section[0] != '\0')
 		return sec->ini_section;
 	return cfg->config_section;
+}
+
+const char* emu_ovl_cfg_section_name(const EmuOvlConfig* cfg, int sec_idx) {
+	if (sec_idx < 0 || sec_idx >= cfg->section_count)
+		return cfg->config_section;
+	return get_ini_section(cfg, &cfg->sections[sec_idx]);
+}
+
+EmuOvlItem* emu_ovl_cfg_find_item(EmuOvlConfig* cfg, const char* ini_section, const char* key, int* out_sec, int* out_item) {
+	if (!cfg || !ini_section || !key)
+		return NULL;
+	for (int s = 0; s < cfg->section_count; s++) {
+		if (strcmp(emu_ovl_cfg_section_name(cfg, s), ini_section) != 0)
+			continue;
+		for (int i = 0; i < cfg->sections[s].item_count; i++) {
+			if (strcmp(cfg->sections[s].items[i].key, key) == 0) {
+				if (out_sec)
+					*out_sec = s;
+				if (out_item)
+					*out_item = i;
+				return &cfg->sections[s].items[i];
+			}
+		}
+	}
+	return NULL;
+}
+
+bool emu_ovl_cfg_parse_value(const EmuOvlItem* item, const char* str, int* out_value) {
+	if (!item || !str || !*str)
+		return false;
+	// Numeric types must actually look numeric. read_ini's atoi/atof
+	// tolerance is fine when re-reading a file we wrote ourselves, but a
+	// per-game override file is arbitrary input and garbage silently
+	// collapsing to 0 would look like a deliberate setting. Bools stay
+	// total, exactly as read_ini treats them (anything not true-ish is 0).
+	if (item->type != EMU_OVL_TYPE_BOOL && !str_is_number(str))
+		return false;
+	int val = parse_item_value(item, str);
+	if (out_value)
+		*out_value = val;
+	return true;
 }
 
 int emu_ovl_cfg_read_ini(EmuOvlConfig* cfg, const char* ini_path) {
@@ -351,22 +422,7 @@ int emu_ovl_cfg_read_ini(EmuOvlConfig* cfg, const char* ini_path) {
 				if (strcmp(item->key, ini_key) != 0)
 					continue;
 
-				int val;
-				switch (item->type) {
-				case EMU_OVL_TYPE_BOOL:
-					val = parse_ini_bool(ini_val);
-					break;
-				case EMU_OVL_TYPE_CYCLE:
-				case EMU_OVL_TYPE_INT:
-					if (item->float_scale > 0)
-						val = (int)(atof(ini_val) * item->float_scale + 0.5);
-					else
-						val = parse_ini_int(ini_val);
-					break;
-				default:
-					val = parse_ini_int(ini_val);
-					break;
-				}
+				int val = parse_item_value(item, ini_val);
 
 				item->current_value = val;
 				item->staged_value = val;
@@ -383,22 +439,36 @@ int emu_ovl_cfg_read_ini(EmuOvlConfig* cfg, const char* ini_path) {
 // INI writing — preserve entire file, only replace matching keys in [section]
 // ---------------------------------------------------------------------------
 
-// Helper: write a single item's value to file
-static void write_item_value(FILE* out, const EmuOvlItem* item) {
+// The one and only value formatter. Widest output is a float_scale value
+// ("-2147483648.000000", 18 chars), so 64 bytes is always enough for the
+// callers below.
+void emu_ovl_cfg_format_value(const EmuOvlItem* item, int value, char* out, int out_size) {
+	if (!out || out_size <= 0)
+		return;
+	out[0] = '\0';
+	if (!item)
+		return;
 	switch (item->type) {
 	case EMU_OVL_TYPE_BOOL:
-		fprintf(out, "%s = %s\n", item->key,
-				item->staged_value ? "True" : "False");
+		snprintf(out, (size_t)out_size, "%s", value ? "True" : "False");
 		break;
 	case EMU_OVL_TYPE_CYCLE:
 	case EMU_OVL_TYPE_INT:
 		if (item->float_scale > 0)
-			fprintf(out, "%s = %f\n", item->key,
-					(double)item->staged_value / item->float_scale);
+			snprintf(out, (size_t)out_size, "%f", (double)value / item->float_scale);
 		else
-			fprintf(out, "%s = %d\n", item->key, item->staged_value);
+			snprintf(out, (size_t)out_size, "%d", value);
 		break;
 	}
+}
+
+// Helper: write a single item's value to file. The "key = value" spacing is
+// load-bearing — flycast's ConfigFile::save() writes exactly this and
+// DC.pak/launch.sh's sed patterns ("^$key =") match on it.
+static void write_item_value(FILE* out, const EmuOvlItem* item) {
+	char value[64];
+	emu_ovl_cfg_format_value(item, item->staged_value, value, sizeof(value));
+	fprintf(out, "%s = %s\n", item->key, value);
 }
 
 // Dirty item tracking with its target INI section name

--- a/workspace/all/common/emu_overlay_cfg.h
+++ b/workspace/all/common/emu_overlay_cfg.h
@@ -57,4 +57,23 @@ void emu_ovl_cfg_reset_section_to_defaults(EmuOvlSection* sec);
 void emu_ovl_cfg_apply_staged(EmuOvlConfig* cfg);
 bool emu_ovl_cfg_has_changes(EmuOvlConfig* cfg);
 
+// Resolved INI section name for sections[sec_idx]: the section's own
+// ini_section when set, else the global config_section (which is also what an
+// out-of-range index returns). Never NULL.
+const char* emu_ovl_cfg_section_name(const EmuOvlConfig* cfg, int sec_idx);
+
+// Find the item with `key` in any schema section resolving to `ini_section`.
+// out_sec/out_item receive the indices when non-NULL. NULL when not found.
+EmuOvlItem* emu_ovl_cfg_find_item(EmuOvlConfig* cfg, const char* ini_section, const char* key, int* out_sec, int* out_item);
+
+// INI string -> internal int, using the exact per-type conversion
+// emu_ovl_cfg_read_ini applies. False (and *out_value untouched) when the
+// string cannot be parsed as this item's type.
+bool emu_ovl_cfg_parse_value(const EmuOvlItem* item, const char* str, int* out_value);
+
+// Internal int -> INI string, the single formatter emu_ovl_cfg_write_ini also
+// goes through. `value` is explicit so callers can format either the staged
+// or the current value. Always NUL-terminates when out_size > 0.
+void emu_ovl_cfg_format_value(const EmuOvlItem* item, int value, char* out, int out_size);
+
 #endif

--- a/workspace/all/emu-options/Makefile
+++ b/workspace/all/emu-options/Makefile
@@ -1,0 +1,42 @@
+###########################################################
+
+ifeq (,$(PLATFORM))
+PLATFORM=$(UNION_PLATFORM)
+endif
+
+ifeq (,$(PLATFORM))
+	$(error please specify PLATFORM, eg. PLATFORM=trimui make)
+endif
+
+ifeq (,$(CROSS_COMPILE))
+	$(error missing CROSS_COMPILE for this toolchain)
+endif
+
+###########################################################
+
+include ../../$(PLATFORM)/platform/Makefile.env
+SDL?=SDL
+
+###########################################################
+
+TARGET = options
+INCDIR = -I. -I../common/ -I../../$(PLATFORM)/platform/
+include ../common/ui/ui.mk
+SOURCE = options.c opts_override.c \
+         ../common/emu_overlay_cfg.c ../common/cjson/cJSON.c \
+         ../common/utils.c ../common/api.c ../common/audio_manager.c ../common/config.c ../common/scaler.c \
+         $(UI_COMPONENT_SRCS) $(UI_DIR)/ui_list.c \
+         ../../$(PLATFORM)/platform/platform.c
+
+CC = $(CROSS_COMPILE)gcc
+CFLAGS  += $(OPT)
+CFLAGS  += $(INCDIR) -I../../$(PLATFORM)/libmsettings -DPLATFORM=\"$(PLATFORM)\" -std=gnu99
+LDFLAGS	 += -L../../$(PLATFORM)/libmsettings -lmsettings -lSDL2_image -lSDL2_ttf -lm -ldl -lz -lpthread
+
+PRODUCT= build/$(PLATFORM)/$(TARGET).elf
+
+all:
+	mkdir -p build/$(PLATFORM)
+	$(CC) $(SOURCE) -o $(PRODUCT) $(CFLAGS) $(LDFLAGS)
+clean:
+	rm -rf build/

--- a/workspace/all/emu-options/options.c
+++ b/workspace/all/emu-options/options.c
@@ -1,0 +1,670 @@
+/*
+ * options.elf — pre-launch emulator options editor and emulator picker.
+ *
+ * Three modes, one binary (the CLI shape Tasks 4/5 script against):
+ *
+ *   options.elf --json J --ini I --game NAME
+ *       Global mode. Edits the device-wide emulator config (flycast's
+ *       emu.cfg) in place, exactly like the in-game overlay's Options screen.
+ *
+ *   options.elf --json J --ini I --override O --game NAME
+ *       Per-game mode. The INI is read for the baseline only; edits land in a
+ *       minimal per-game override file that carries just the diff (see
+ *       opts_override.h). Rows that differ from the global value are marked
+ *       with a leading "* ".
+ *
+ *   options.elf --pick --entry NAME PATH [--entry NAME PATH ...]
+ *       Emulator picker. Prints the chosen PATH on stdout and nothing else,
+ *       exit 0; exit 1 when the user backs out.
+ *
+ * Exit codes: 0 save-and-exit (or a picked entry), 1 picker cancelled / config
+ * could not be loaded, 2 usage error.
+ */
+
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <msettings.h>
+
+#include "defines.h"
+#include "api.h"
+#include "emu_overlay_cfg.h"
+#include "opts_override.h"
+#include "ui_buttonhintbar.h"
+#include "ui_list.h"
+#include "ui_menubar.h"
+#include "ui_message.h"
+#include "ui_splash.h"
+
+// --entry pairs accepted in picker mode; extras are reported and dropped.
+#define MAX_PICK_ENTRIES 16
+// Longest screen is a section's items plus the trailing reset row.
+#define MAX_ROWS (EMU_OVL_MAX_ITEMS + 1)
+/*
+ * A section name, or an item's "* " + label. 256 is far more than either needs
+ * — the longest label the shipped schemas carry is mupen64plus's 22-char
+ * "Hi-Res Noise Dithering" — and the buffer size is not what keeps a row
+ * legible anyway: the section screen's pill truncates to fit, but
+ * UI_renderSettingsRow measures and blits an item label whole, so a long
+ * enough user-authored label runs under the value column. That is the
+ * component's limitation, shared with every screen built on it.
+ */
+#define ROW_TEXT_MAX 256
+// Right-hand value column on the item screen; the row right-aligns and clips it.
+#define ROW_VALUE_MAX 64
+// How long a terminal message stays up before the process moves on (ms).
+#define OPTS_MESSAGE_MS 2000
+
+// EmuOvlConfig is ~1.3 MB (16 sections x 32 items x a 2.5 KB item) and
+// OptsOverrideState another ~2.5 KB; neither belongs on this binary's stack.
+static EmuOvlConfig cfg;
+static OptsOverrideState st;
+
+// Row text for whichever list is on screen, rebuilt on every state change and
+// after every edit.
+static char row_text[MAX_ROWS][ROW_TEXT_MAX];
+// Section screen only: the pill list takes an array of label pointers.
+static const char* row_ptr[MAX_ROWS];
+/*
+ * Item screen only. UI_renderSettingsPage borrows every string by pointer, and
+ * the rows are built once per state change but rendered on many later frames,
+ * so nothing it reads may live on the builder's stack: hence a values table
+ * beside row_text, a row_item[] that outlives build_item_rows, and .desc
+ * pointed straight into the (also file-scope) cfg.
+ */
+static char row_value[MAX_ROWS][ROW_VALUE_MAX];
+static UISettingsItem row_item[MAX_ROWS];
+
+static SDL_Surface* screen = NULL;
+
+//////////////////////////////////
+// Screens
+//////////////////////////////////
+
+/*
+ * Pill list, used by the picker and the section screen.
+ *
+ * This is UI_renderSimpleMenu's body with the button hints hoisted into a
+ * parameter. That function hardcodes its A hint to "OPEN", which is wrong on
+ * the picker — A picks an emulator there — and its hint bar cannot be
+ * suppressed, so drawing a second one over it would stack UI_getScrim's
+ * 70%-opaque black twice and leave the first bar's labels showing through.
+ * Everything else is the same shared components UI_renderSimpleMenu uses.
+ */
+static void render_list(const char* title, const char** labels, int count,
+						int selected, int* scroll, char** hints) {
+	GFX_clear(screen);
+	UI_renderMenuBar(screen, title);
+
+	ListLayout layout = UI_calcListLayout(screen);
+	UI_adjustListScroll(selected, scroll, layout.items_per_page);
+
+	int visible = count - *scroll;
+	if (visible > layout.items_per_page)
+		visible = layout.items_per_page;
+	if (visible < 0)
+		visible = 0;
+
+	char truncated[ROW_TEXT_MAX];
+	for (int i = 0; i < visible; i++) {
+		int idx = *scroll + i;
+		bool is_selected = (idx == selected);
+		MenuItemPos pos = UI_renderMenuItemPill(screen, &layout, labels[idx], truncated, i, is_selected, 0);
+		UI_renderListItemText(screen, NULL, truncated, font.large,
+							  pos.text_x, pos.text_y, layout.max_width, is_selected);
+	}
+
+	UI_renderScrollIndicators(screen, *scroll, layout.items_per_page, count);
+
+	UI_renderButtonHintBar(screen, hints);
+	GFX_flip(screen);
+}
+
+/*
+ * Item screen: the Settings app's two-column rows (label pill left, value
+ * right, "< value >" on the selected row) instead of one long "Label: Value"
+ * pill. SETTINGS_ROW_COUNT short rows fit where the pill list fit
+ * list_h/PILL_SIZE tall ones, and the component's last row carries the
+ * selected item's description — which is where the schema's options_hint now
+ * lands too, as the fallback for items that ship no description of their own.
+ *
+ * `selected` is absolute (the component windows it itself), and the component
+ * runs UI_adjustListScroll on *scroll, so nothing outside touches it.
+ *
+ * UI_renderSettingsPage rewrites layout.item_h/items_per_page for its own row
+ * count, so the layout is recomputed here every frame rather than shared with
+ * render_list. The component draws no chrome: bar, hints and flip stay here.
+ *
+ * The hints are the one piece of chrome this screen cannot hand in from the
+ * outside, because they change per row — so they are built here rather than
+ * passed as a parameter.
+ */
+static void render_item_page(const char* title, UISettingsItem* items, int count,
+							 int selected, int* scroll) {
+	GFX_clear(screen);
+	UI_renderMenuBar(screen, title);
+
+	ListLayout layout = UI_calcListLayout(screen);
+	UI_renderSettingsPage(screen, &layout, items, count, selected, scroll, NULL);
+
+	/*
+	 * Keyed off the very flag the component draws its "< >" arrows from, so the
+	 * hint and the row it describes can never disagree: an arrow-less row (the
+	 * reset row) is pressed, a cycleable one is stepped. Same shape as the other
+	 * screens on this component — portmaster.c:781-786,
+	 * musicplayer/ui_settings.c:69-81. A still cycles a value as well as
+	 * LEFT/RIGHT, but the bar names the arrows the row is showing.
+	 */
+	bool cycleable = (selected >= 0 && selected < count && items[selected].cycleable);
+	UI_renderButtonHintBar(screen, (char*[]){
+									   cycleable ? "LEFT/RIGHT" : "A",
+									   cycleable ? "CHANGE" : "SELECT",
+									   "B", "BACK",
+									   NULL});
+	GFX_flip(screen);
+}
+
+static void show_message(const char* message, int hold_ms) {
+	GFX_clear(screen);
+	UI_renderCenteredMessage(screen, message);
+	GFX_flip(screen);
+	SDL_Delay(hold_ms);
+}
+
+//////////////////////////////////
+// Picker
+//////////////////////////////////
+
+/*
+ * stdout is the picker's return channel, so it has to stay clean. GFX_init,
+ * InitSettings and the platform layer all log with plain printf, and the
+ * callers in Task 5 read this process's stdout — park the real stdout on a
+ * spare descriptor and point fd 1 at stderr until there is an answer to print.
+ * Returns the saved descriptor, or -1 when the redirect could not be set up
+ * (in which case nothing was changed and no restore is needed).
+ *
+ * FD_CLOEXEC on the saved descriptor is not hygiene, it is the fix for a hang.
+ * The caller captures us in a command substitution
+ * (Emulator Settings.pak/launch.sh: CHOSEN="$(options.elf --pick ...)"), so
+ * `saved` is the write end of that pipe, and the shell's read only returns at
+ * EOF — i.e. when every copy of the write end is closed. On tg5050,
+ * InitSettings() below calls SetRawFanSpeed(-2), which runs
+ * system("…/fancontrol normal &") (tg5050/libmsettings/msettings.c:1092-1115).
+ * That trailing & leaves a daemon alive after we exit, and without CLOEXEC it
+ * inherits `saved` and holds the pipe open forever: the picker exits 0, the
+ * chosen path is printed, and Tools -> Emulator Settings still hangs on a black
+ * screen waiting for EOF. tg5040 ships no fan daemon, which is the only reason
+ * it ever worked there. Set it the moment the dup succeeds, so no exec between
+ * here and stdout_restore can leak it, whatever a platform decides to spawn.
+ *
+ * fd 1 and fd 2 are inherited by those children too, and are deliberately left
+ * alone: launch.sh points stderr at a log file, so a daemon holding it open
+ * blocks nothing. Only a pipe end can stall the capture.
+ */
+static int stdout_park(void) {
+	int saved = dup(STDOUT_FILENO);
+	if (saved < 0)
+		return -1;
+	fcntl(saved, F_SETFD, FD_CLOEXEC);
+	if (dup2(STDERR_FILENO, STDOUT_FILENO) < 0) {
+		close(saved);
+		return -1;
+	}
+	return saved;
+}
+
+static void stdout_restore(int saved) {
+	if (saved < 0)
+		return;
+	fflush(stdout);
+	dup2(saved, STDOUT_FILENO);
+	close(saved);
+}
+
+// Returns 0 with *out_path pointing into argv when an entry was chosen,
+// 1 when the user backed out, 2 when there was nothing to pick.
+static int run_picker(int argc, char** argv, const char** out_path) {
+	const char* names[MAX_PICK_ENTRIES];
+	const char* paths[MAX_PICK_ENTRIES];
+	int count = 0;
+
+	for (int i = 1; i < argc; i++) {
+		if (strcmp(argv[i], "--entry") != 0 || i + 2 >= argc)
+			continue;
+		if (count < MAX_PICK_ENTRIES) {
+			names[count] = argv[i + 1];
+			paths[count] = argv[i + 2];
+			count++;
+		} else {
+			fprintf(stderr, "options: ignoring --entry '%s' (max %d)\n", argv[i + 1], MAX_PICK_ENTRIES);
+		}
+		i += 2;
+	}
+
+	// main rejects this before GFX_init; kept so the loop below can never run
+	// with an empty list (PAD_navigateMenu would divide the cursor by nothing).
+	if (count == 0)
+		return 2;
+
+	int selected = 0;
+	int scroll = 0;
+	bool dirty = true;
+	IndicatorType show_setting = INDICATOR_NONE;
+
+	while (1) {
+		GFX_startFrame();
+		PAD_poll();
+		PWR_update(&dirty, &show_setting, NULL, NULL);
+
+		if (UI_statusBarChanged())
+			dirty = true;
+
+		if (PAD_navigateMenu(&selected, count)) {
+			dirty = true;
+		} else if (PAD_justPressed(BTN_A)) {
+			*out_path = paths[selected];
+			return 0;
+		} else if (PAD_justPressed(BTN_B)) {
+			return 1;
+		}
+
+		if (dirty) {
+			render_list("Emulator Settings", names, count, selected, &scroll,
+						(char*[]){"A", "SELECT", "B", "BACK", NULL});
+			dirty = false;
+		} else {
+			GFX_sync();
+		}
+	}
+}
+
+//////////////////////////////////
+// Editing
+//////////////////////////////////
+
+// BOOL toggles, CYCLE steps through values[] with wrap, INT steps by int_step
+// and clamps (unlike the in-game overlay's wrap: that screen only has a "next"
+// action, this one has LEFT and RIGHT).
+static void cycle_item(EmuOvlItem* item, int dir) {
+	switch (item->type) {
+	case EMU_OVL_TYPE_BOOL:
+		item->staged_value = item->staged_value ? 0 : 1;
+		break;
+	case EMU_OVL_TYPE_CYCLE: {
+		if (item->value_count <= 0)
+			break;
+		int idx = 0;
+		for (int i = 0; i < item->value_count; i++) {
+			if (item->values[i] == item->staged_value) {
+				idx = i;
+				break;
+			}
+		}
+		idx = (idx + dir + item->value_count) % item->value_count;
+		item->staged_value = item->values[idx];
+		break;
+	}
+	case EMU_OVL_TYPE_INT:
+		item->staged_value += dir * item->int_step;
+		if (item->staged_value > item->int_max)
+			item->staged_value = item->int_max;
+		else if (item->staged_value < item->int_min)
+			item->staged_value = item->int_min;
+		break;
+	}
+}
+
+// Per-game mode: back to the device-global value. Global mode: back to the
+// schema default (the same primitive the in-game overlay's reset row uses).
+static void reset_section(int s, bool per_game) {
+	if (!per_game) {
+		emu_ovl_cfg_reset_section_to_defaults(&cfg.sections[s]);
+		return;
+	}
+	for (int i = 0; i < cfg.sections[s].item_count; i++)
+		cfg.sections[s].items[i].staged_value = st.global_value[s][i];
+}
+
+static void clear_all_overrides(void) {
+	for (int s = 0; s < cfg.section_count; s++)
+		reset_section(s, true);
+}
+
+// Staged items that still differ from the global baseline, i.e. what
+// opts_write_override would put in the file.
+static int count_overrides(void) {
+	int n = 0;
+	for (int s = 0; s < cfg.section_count; s++)
+		for (int i = 0; i < cfg.sections[s].item_count; i++)
+			if (cfg.sections[s].items[i].staged_value != st.global_value[s][i])
+				n++;
+	return n;
+}
+
+// The row's left column: the schema label, with a leading "* " when the row
+// overrides the global value.
+static void row_label(const EmuOvlItem* item, bool overridden, char* out, int out_size) {
+	snprintf(out, out_size, "%s%s", overridden ? "* " : "", item->label);
+}
+
+// The row's right column. The value shown is the STAGED one, so edits are
+// visible immediately, and it prefers the schema's human label over
+// emu_ovl_cfg_format_value's output — that formatter speaks the INI's dialect
+// ("True"/"False", raw ints), which is right for the file and wrong for a row.
+static void row_value_text(const EmuOvlItem* item, char* out, int out_size) {
+	const char* human = NULL;
+
+	for (int v = 0; v < item->value_count; v++) {
+		if (item->values[v] == item->staged_value && item->labels[v][0] != '\0') {
+			human = item->labels[v];
+			break;
+		}
+	}
+
+	if (human)
+		snprintf(out, out_size, "%s", human);
+	else if (item->type == EMU_OVL_TYPE_BOOL)
+		// Matches the in-game overlay's On/Off; the shipped schemas give bools
+		// no labels[] of their own.
+		snprintf(out, out_size, "%s", item->staged_value ? "On" : "Off");
+	else
+		emu_ovl_cfg_format_value(item, item->staged_value, out, out_size);
+}
+
+static int build_section_rows(bool per_game) {
+	int n = 0;
+	for (int s = 0; s < cfg.section_count && n < MAX_ROWS; s++)
+		snprintf(row_text[n++], ROW_TEXT_MAX, "%s", cfg.sections[s].name);
+	// The count is this row's only feedback: clearing overrides changes nothing
+	// on this screen (section rows carry no values), so without it a press of A
+	// here looks like it did nothing at all.
+	if (per_game && n < MAX_ROWS)
+		snprintf(row_text[n++], ROW_TEXT_MAX, "Clear All Overrides (%d)", count_overrides());
+	for (int i = 0; i < n; i++)
+		row_ptr[i] = row_text[i];
+	return n;
+}
+
+/*
+ * Fills row_item[] for the item screen. `.swatch` is -1 on every row: zero
+ * would be a valid colour (black) to UI_renderSettingsRow, not "no swatch".
+ * `.desc` prefers the item's own description and falls back to the schema's
+ * options_hint, which is how the "Restart game to apply changes" notice stays
+ * on screen now that the hand-rolled footer is gone.
+ */
+static int build_item_rows(int s, bool per_game) {
+	EmuOvlSection* sec = &cfg.sections[s];
+	int n = 0;
+	for (int i = 0; i < sec->item_count && n < MAX_ROWS - 1; i++) {
+		const EmuOvlItem* item = &sec->items[i];
+		// Recomputed from staged_value on every rebuild, so the marker tracks
+		// the edit in progress; on entry it matches the file because
+		// opts_read_override staged what it read.
+		bool overridden = per_game && item->staged_value != st.global_value[s][i];
+		row_label(item, overridden, row_text[n], ROW_TEXT_MAX);
+		row_value_text(item, row_value[n], ROW_VALUE_MAX);
+		row_item[n] = (UISettingsItem){
+			.label = row_text[n],
+			.value = row_value[n],
+			.swatch = -1,
+			.cycleable = 1,
+			.desc = item->description[0] != '\0' ? item->description : cfg.options_hint,
+		};
+		n++;
+	}
+	// No value, so UI_renderSettingsRow gives it the label-only highlight the
+	// other reset rows in this UI get rather than a "< >" value column.
+	snprintf(row_text[n], ROW_TEXT_MAX, "%s", per_game ? "Reset to Global" : "Reset to Default");
+	row_item[n] = (UISettingsItem){
+		.label = row_text[n],
+		.value = NULL,
+		.swatch = -1,
+		.cycleable = 0,
+		.desc = cfg.options_hint,
+	};
+	n++;
+	return n;
+}
+
+typedef enum { ED_SECTIONS,
+			   ED_ITEMS } EdState;
+
+// Runs until B on the section list. Nothing here touches the SD card: every
+// edit moves staged_value only, and the single write happens in save_edits().
+static void run_editor(const char* title, bool per_game) {
+	EdState state = ED_SECTIONS;
+	int section_selected = 0;
+	int section_scroll = 0;
+	int item_selected = 0;
+	int item_scroll = 0;
+	int current_section = 0;
+	int row_count = build_section_rows(per_game);
+	bool dirty = true;
+	bool done = false;
+	IndicatorType show_setting = INDICATOR_NONE;
+
+	while (!done) {
+		GFX_startFrame();
+		PAD_poll();
+		PWR_update(&dirty, &show_setting, NULL, NULL);
+
+		if (UI_statusBarChanged())
+			dirty = true;
+
+		if (state == ED_SECTIONS) {
+			if (PAD_navigateMenu(&section_selected, row_count)) {
+				dirty = true;
+			} else if (PAD_justPressed(BTN_A)) {
+				if (section_selected >= cfg.section_count) {
+					clear_all_overrides(); // the trailing per-game row
+					row_count = build_section_rows(per_game);
+				} else {
+					current_section = section_selected;
+					item_selected = 0;
+					item_scroll = 0;
+					row_count = build_item_rows(current_section, per_game);
+					state = ED_ITEMS;
+				}
+				dirty = true;
+			} else if (PAD_justPressed(BTN_B)) {
+				done = true;
+			}
+		} else {
+			EmuOvlSection* sec = &cfg.sections[current_section];
+
+			if (PAD_navigateMenu(&item_selected, row_count)) {
+				dirty = true;
+			} else if (PAD_justPressed(BTN_B)) {
+				section_selected = current_section;
+				row_count = build_section_rows(per_game);
+				state = ED_SECTIONS;
+				dirty = true;
+			} else if (item_selected >= sec->item_count) {
+				if (PAD_justPressed(BTN_A)) {
+					reset_section(current_section, per_game);
+					row_count = build_item_rows(current_section, per_game);
+					dirty = true;
+				}
+			} else {
+				int dir = 0;
+				if (PAD_justPressed(BTN_A) || PAD_justRepeated(BTN_RIGHT))
+					dir = 1;
+				else if (PAD_justRepeated(BTN_LEFT))
+					dir = -1;
+				if (dir != 0) {
+					cycle_item(&sec->items[item_selected], dir);
+					row_count = build_item_rows(current_section, per_game);
+					dirty = true;
+				}
+			}
+		}
+
+		if (dirty) {
+			if (state == ED_SECTIONS)
+				render_list(title, row_ptr, row_count, section_selected, &section_scroll,
+							(char*[]){"A", "OPEN", "B", "SAVE", NULL});
+			else
+				render_item_page(cfg.sections[current_section].name, row_item, row_count,
+								 item_selected, &item_scroll);
+			dirty = false;
+		} else {
+			GFX_sync();
+		}
+	}
+}
+
+// The one and only write, on the way out. Per cursor move would mean an SD
+// card write per D-pad press.
+static void save_edits(bool per_game, const char* ini_path, const char* override_path) {
+	if (per_game) {
+		// Writes the staged-vs-global diff, or unlinks the file when there is
+		// none; syncs on its own.
+		if (opts_write_override(&cfg, &st, override_path) < 0) {
+			fprintf(stderr, "options: failed to write override %s\n", override_path);
+			show_message("Failed to save - check SD card", OPTS_MESSAGE_MS);
+			return;
+		}
+		opts_commit(&cfg, &st);
+		return;
+	}
+
+	// Global mode. emu_ovl_cfg_write_ini/has_changes/apply_staged all dispatch
+	// on item->dirty, and this editor moves staged_value without setting it
+	// (opts_commit does the same flagging for the per-game path), so flag what
+	// actually moved first. The call order below is the in-game overlay's on
+	// close — flycast.patch's write_config_if_dirty(): has_changes -> write_ini
+	// -> apply_staged. The patch's cfgSaveBool/cfgSaveInt step between the last
+	// two has no counterpart here: flycast is not running yet, so there is no
+	// in-memory cfgdb to keep in sync, and it loads this file on start-up.
+	for (int s = 0; s < cfg.section_count; s++) {
+		for (int i = 0; i < cfg.sections[s].item_count; i++) {
+			EmuOvlItem* item = &cfg.sections[s].items[i];
+			if (item->staged_value != item->current_value)
+				item->dirty = true;
+		}
+	}
+
+	if (!emu_ovl_cfg_has_changes(&cfg))
+		return;
+
+	if (emu_ovl_cfg_write_ini(&cfg, ini_path) < 0) {
+		fprintf(stderr, "options: failed to write ini %s\n", ini_path);
+		show_message("Failed to save - check SD card", OPTS_MESSAGE_MS);
+		return;
+	}
+	emu_ovl_cfg_apply_staged(&cfg);
+	sync();
+}
+
+//////////////////////////////////
+// main
+//////////////////////////////////
+
+int main(int argc, char* argv[]) {
+	const char* json_path = NULL;
+	const char* ini_path = NULL;
+	const char* override_path = NULL;
+	const char* game_name = NULL;
+	bool pick = false;
+	int entry_count = 0;
+
+	for (int i = 1; i < argc; i++) {
+		const char* arg = argv[i];
+		bool has_value = (i + 1 < argc);
+
+		if (strcmp(arg, "--pick") == 0) {
+			pick = true;
+		} else if (strcmp(arg, "--json") == 0 && has_value) {
+			json_path = argv[++i];
+		} else if (strcmp(arg, "--ini") == 0 && has_value) {
+			ini_path = argv[++i];
+		} else if (strcmp(arg, "--override") == 0 && has_value) {
+			override_path = argv[++i];
+		} else if (strcmp(arg, "--game") == 0 && has_value) {
+			game_name = argv[++i];
+		} else if (strcmp(arg, "--entry") == 0 && i + 2 < argc) {
+			entry_count++;
+			i += 2; // run_picker re-walks argv for these
+		} else {
+			fprintf(stderr, "options: unknown or incomplete argument '%s'\n", arg);
+			return 2;
+		}
+	}
+
+	// Both usage checks run before GFX_init: a usage error must not cost the
+	// caller a black screen and a video teardown.
+	if (pick && entry_count == 0) {
+		fprintf(stderr, "options: --pick needs at least one '--entry NAME PATH'\n");
+		return 2;
+	}
+	if (!pick && (!json_path || !ini_path)) {
+		fprintf(stderr, "options: --json and --ini are required\n");
+		return 2;
+	}
+
+	int saved_stdout = pick ? stdout_park() : -1;
+
+	screen = GFX_init(MODE_MAIN);
+	UI_showSplashScreen(screen, game_name ? game_name : "Emulator Settings");
+
+	PWR_pinToCores(CPU_CORE_EFFICIENCY);
+	InitSettings();
+	PAD_init();
+	PWR_init();
+
+	// This process sits between the launcher and the emulator; a sleep or an
+	// auto power-off here would strand the launch script.
+	PWR_disableSleep();
+	PWR_disableAutosleep();
+	PWR_disablePowerOff();
+
+	int exit_code = 0;
+	const char* picked_path = NULL;
+
+	if (pick) {
+		exit_code = run_picker(argc, argv, &picked_path);
+	} else if (emu_ovl_cfg_load(&cfg, json_path) != 0) {
+		fprintf(stderr, "options: failed to load schema %s\n", json_path);
+		show_message("Settings unavailable", OPTS_MESSAGE_MS);
+		exit_code = 1;
+	} else if (emu_ovl_cfg_read_ini(&cfg, ini_path) != 0) {
+		fprintf(stderr, "options: failed to read config %s\n", ini_path);
+		show_message("Settings unavailable", OPTS_MESSAGE_MS);
+		exit_code = 1;
+	} else {
+		bool per_game = (override_path != NULL);
+
+		// Baseline first, then layer the override on top: opts_read_override
+		// rewrites current_value, so a snapshot taken after it would record
+		// the overridden value as the global one and the diff would come out
+		// empty.
+		opts_snapshot_globals(&cfg, &st);
+		if (per_game)
+			opts_read_override(&cfg, &st, override_path);
+
+		run_editor(game_name ? game_name : "Emulator Settings", per_game);
+		save_edits(per_game, ini_path, override_path);
+		emu_ovl_cfg_free(&cfg);
+	}
+
+	PWR_enableSleep();
+	PWR_enableAutosleep();
+
+	QuitSettings();
+	PWR_quit();
+	PAD_quit();
+	GFX_quit();
+
+	// After GFX_quit, so nothing the teardown logs can reach the real stdout.
+	if (pick) {
+		stdout_restore(saved_stdout);
+		if (picked_path)
+			printf("%s\n", picked_path);
+	}
+
+	return exit_code;
+}

--- a/workspace/all/emu-options/opts_override.c
+++ b/workspace/all/emu-options/opts_override.c
@@ -1,0 +1,148 @@
+#include "opts_override.h"
+
+#include <ctype.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+void opts_snapshot_globals(const EmuOvlConfig* cfg, OptsOverrideState* st) {
+	if (!st)
+		return;
+	memset(st, 0, sizeof(*st));
+	if (!cfg)
+		return;
+	for (int s = 0; s < cfg->section_count; s++)
+		for (int i = 0; i < cfg->sections[s].item_count; i++)
+			st->global_value[s][i] = cfg->sections[s].items[i].current_value;
+}
+
+static char* trim(char* s) {
+	while (isspace((unsigned char)*s))
+		s++;
+	char* end = s + strlen(s);
+	while (end > s && isspace((unsigned char)end[-1]))
+		*--end = '\0';
+	return s;
+}
+
+int opts_read_override(EmuOvlConfig* cfg, OptsOverrideState* st, const char* override_path) {
+	if (!cfg || !st || !override_path)
+		return 0;
+	FILE* f = fopen(override_path, "r");
+	if (!f)
+		return 0;
+	char line[512];
+	char section[EMU_OVL_MAX_STR] = "";
+	int applied = 0;
+	while (fgets(line, sizeof(line), f)) {
+		char* p = trim(line);
+		if (*p == '\0' || *p == '#' || *p == ';')
+			continue;
+		size_t len = strlen(p);
+		if (*p == '[' && p[len - 1] == ']') {
+			p[len - 1] = '\0';
+			snprintf(section, sizeof(section), "%s", p + 1);
+			continue;
+		}
+		char* eq = strchr(p, '=');
+		if (!eq || section[0] == '\0')
+			continue;
+		*eq = '\0';
+		char* key = trim(p);
+		char* val = trim(eq + 1);
+		int s = -1, i = -1;
+		EmuOvlItem* item = emu_ovl_cfg_find_item(cfg, section, key, &s, &i);
+		if (!item)
+			continue;
+		int value;
+		if (!emu_ovl_cfg_parse_value(item, val, &value))
+			continue;
+		item->current_value = value;
+		item->staged_value = value;
+		st->overridden[s][i] = true;
+		applied++;
+	}
+	fclose(f);
+	return applied;
+}
+
+int opts_write_override(EmuOvlConfig* cfg, const OptsOverrideState* st, const char* override_path) {
+	if (!cfg || !st || !override_path)
+		return -1;
+	// collect the diff first so an all-clean state unlinks instead of writing
+	int diff_count = 0;
+	for (int s = 0; s < cfg->section_count; s++)
+		for (int i = 0; i < cfg->sections[s].item_count; i++)
+			if (cfg->sections[s].items[i].staged_value != st->global_value[s][i])
+				diff_count++;
+	if (diff_count == 0) {
+		unlink(override_path);
+		return 0;
+	}
+	FILE* f = fopen(override_path, "w");
+	if (!f)
+		return -1;
+	// group by resolved ini_section name, first-seen order, no duplicates
+	const char* done[EMU_OVL_MAX_SECTIONS] = {0};
+	int done_count = 0;
+	int written = 0;
+	for (int s = 0; s < cfg->section_count; s++) {
+		const char* name = emu_ovl_cfg_section_name(cfg, s);
+		bool seen = false;
+		for (int d = 0; d < done_count; d++)
+			if (strcmp(done[d], name) == 0)
+				seen = true;
+		if (seen)
+			continue;
+		done[done_count++] = name;
+		// does any schema section resolving to `name` have a diff?
+		bool any = false;
+		for (int s2 = 0; s2 < cfg->section_count; s2++) {
+			if (strcmp(emu_ovl_cfg_section_name(cfg, s2), name) != 0)
+				continue;
+			for (int i = 0; i < cfg->sections[s2].item_count; i++)
+				if (cfg->sections[s2].items[i].staged_value != st->global_value[s2][i])
+					any = true;
+		}
+		if (!any)
+			continue;
+		fprintf(f, "[%s]\n", name);
+		for (int s2 = 0; s2 < cfg->section_count; s2++) {
+			if (strcmp(emu_ovl_cfg_section_name(cfg, s2), name) != 0)
+				continue;
+			for (int i = 0; i < cfg->sections[s2].item_count; i++) {
+				EmuOvlItem* item = &cfg->sections[s2].items[i];
+				if (item->staged_value == st->global_value[s2][i])
+					continue;
+				char value[64];
+				emu_ovl_cfg_format_value(item, item->staged_value, value, sizeof(value));
+				// single spaces around '=' are load-bearing: flycast and
+				// DC.pak/launch.sh's sed patterns both expect "key = value"
+				fprintf(f, "%s = %s\n", item->key, value);
+				written++;
+			}
+		}
+		fprintf(f, "\n");
+	}
+	fclose(f);
+	sync();
+	return written;
+}
+
+void opts_commit(EmuOvlConfig* cfg, OptsOverrideState* st) {
+	if (!cfg || !st)
+		return;
+	for (int s = 0; s < cfg->section_count; s++) {
+		for (int i = 0; i < cfg->sections[s].item_count; i++) {
+			EmuOvlItem* item = &cfg->sections[s].items[i];
+			st->overridden[s][i] = item->staged_value != st->global_value[s][i];
+			// emu_ovl_cfg_apply_staged only commits items flagged dirty, and
+			// the options editor may have moved staged_value without setting
+			// the flag (opts_read_override does exactly that), so flag
+			// anything that actually moved before delegating.
+			if (item->staged_value != item->current_value)
+				item->dirty = true;
+		}
+	}
+	emu_ovl_cfg_apply_staged(cfg);
+}

--- a/workspace/all/emu-options/opts_override.h
+++ b/workspace/all/emu-options/opts_override.h
@@ -1,0 +1,39 @@
+#ifndef OPTS_OVERRIDE_H
+#define OPTS_OVERRIDE_H
+
+#include "emu_overlay_cfg.h"
+
+// Per-game override layer on top of the device-global emu.cfg.
+// Lifecycle: load JSON -> read_ini(emu.cfg) -> opts_snapshot_globals ->
+// opts_read_override -> user edits staged_value -> opts_write_override ->
+// opts_commit.
+
+typedef struct {
+	// current_value of every item right after reading the global INI
+	int global_value[EMU_OVL_MAX_SECTIONS][EMU_OVL_MAX_ITEMS];
+	// key was present in the override file (drives the UI's override marker)
+	bool overridden[EMU_OVL_MAX_SECTIONS][EMU_OVL_MAX_ITEMS];
+} OptsOverrideState;
+
+// Snapshot every item's current_value as the global baseline. Call after
+// emu_ovl_cfg_read_ini(cfg, <emu.cfg>).
+void opts_snapshot_globals(const EmuOvlConfig* cfg, OptsOverrideState* st);
+
+// Layer an override INI on top: for each recognized [section] key = value,
+// set the item's current_value and staged_value and mark st->overridden.
+// Unknown sections/keys and unparseable values are skipped. Missing or
+// unreadable file is a no-op. Returns the number of keys applied.
+int opts_read_override(EmuOvlConfig* cfg, OptsOverrideState* st, const char* override_path);
+
+// Write the staged-vs-global diff as a minimal INI (sections in first-seen
+// resolved-name order, "key = value" lines matching emu.cfg's dialect).
+// When no item differs from its global baseline the file is unlinked
+// instead. Returns the number of keys written (0 after an unlink), -1 on
+// I/O error.
+int opts_write_override(EmuOvlConfig* cfg, const OptsOverrideState* st, const char* override_path);
+
+// After a successful opts_write_override: refresh st->overridden from the
+// staged-vs-global diff and commit staged -> current.
+void opts_commit(EmuOvlConfig* cfg, OptsOverrideState* st);
+
+#endif

--- a/workspace/all/emu-options/tests/test_opts_override.c
+++ b/workspace/all/emu-options/tests/test_opts_override.c
@@ -1,0 +1,335 @@
+// Host-side tests for opts_override.c
+// Build+run:
+//   cd workspace/all/emu-options/tests && mkdir -p build && \
+//   cc -std=gnu99 -Wall -o build/test_opts_override test_opts_override.c \
+//      ../opts_override.c ../../common/emu_overlay_cfg.c ../../common/cjson/cJSON.c \
+//      -I.. -I../../common && \
+//   ./build/test_opts_override
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "emu_overlay_cfg.h"
+#include "opts_override.h"
+
+#define ROOT "build/opts_test_root"
+
+static void reset_root(void) {
+	system("rm -rf " ROOT);
+	system("mkdir -p " ROOT);
+}
+
+static void write_file(const char* path, const char* content) {
+	FILE* f = fopen(path, "w");
+	assert(f);
+	fputs(content, f);
+	fclose(f);
+}
+
+static int file_exists(const char* path) {
+	FILE* f = fopen(path, "r");
+	if (!f)
+		return 0;
+	fclose(f);
+	return 1;
+}
+
+// Minimal schema mirroring the real overlay_settings.json shapes:
+// global config_section "config"; one bool in [config], one bool with
+// ini_section "achievements", one cycle in ini_section "network".
+// Key names and value shapes match parse_item()/parse_section() exactly:
+// bool defaults are JSON booleans (json_get_bool ignores numbers), cycle
+// defaults are JSON numbers.
+static const char* SCHEMA =
+	"{\n"
+	"  \"emulator\": \"flycast\",\n"
+	"  \"config_file\": \"emu.cfg\",\n"
+	"  \"config_section\": \"config\",\n"
+	"  \"options_hint\": \"Restart game to apply changes\",\n"
+	"  \"save_state\": true,\n"
+	"  \"load_state\": true,\n"
+	"  \"sections\": [\n"
+	"    {\"name\": \"Video\", \"items\": [\n"
+	"      {\"key\": \"rend.WideScreen\", \"label\": \"Widescreen\", \"type\": \"bool\", \"default\": false}\n"
+	"    ]},\n"
+	"    {\"name\": \"RetroAchievements\", \"ini_section\": \"achievements\", \"items\": [\n"
+	"      {\"key\": \"Enabled\", \"label\": \"Enabled\", \"type\": \"bool\", \"default\": false}\n"
+	"    ]},\n"
+	"    {\"name\": \"Netplay\", \"ini_section\": \"network\", \"items\": [\n"
+	"      {\"key\": \"GGPODelay\", \"label\": \"Input Delay\", \"type\": \"cycle\",\n"
+	"       \"values\": [0,1,2,3,4,5], \"labels\": [\"0\",\"1\",\"2\",\"3\",\"4\",\"5\"], \"default\": 0}\n"
+	"    ]}\n"
+	"  ]\n"
+	"}\n";
+
+static const char* GLOBAL_INI =
+	"[config]\n"
+	"rend.WideScreen = no\n"
+	"\n"
+	"[achievements]\n"
+	"Enabled = yes\n"
+	"\n"
+	"[network]\n"
+	"GGPODelay = 0\n";
+
+static void setup(EmuOvlConfig* cfg, OptsOverrideState* st) {
+	reset_root();
+	write_file(ROOT "/schema.json", SCHEMA);
+	write_file(ROOT "/emu.cfg", GLOBAL_INI);
+	memset(cfg, 0, sizeof(*cfg));
+	assert(emu_ovl_cfg_load(cfg, ROOT "/schema.json") == 0);
+	assert(emu_ovl_cfg_read_ini(cfg, ROOT "/emu.cfg") == 0);
+	opts_snapshot_globals(cfg, st);
+}
+
+static EmuOvlItem* item(EmuOvlConfig* cfg, const char* sec, const char* key) {
+	EmuOvlItem* it = emu_ovl_cfg_find_item(cfg, sec, key, NULL, NULL);
+	assert(it);
+	return it;
+}
+
+// The schema must actually have loaded the way the parser reads it —
+// otherwise every other test below would pass against an empty config.
+static void test_schema_loads(void) {
+	EmuOvlConfig cfg;
+	OptsOverrideState st;
+	setup(&cfg, &st);
+	assert(cfg.section_count == 3);
+	assert(strcmp(cfg.config_section, "config") == 0);
+	// resolved section names: no ini_section falls back to config_section
+	assert(strcmp(emu_ovl_cfg_section_name(&cfg, 0), "config") == 0);
+	assert(strcmp(emu_ovl_cfg_section_name(&cfg, 1), "achievements") == 0);
+	assert(strcmp(emu_ovl_cfg_section_name(&cfg, 2), "network") == 0);
+	// out-of-range index falls back to the global section
+	assert(strcmp(emu_ovl_cfg_section_name(&cfg, 99), "config") == 0);
+	// unknown section / unknown key must not match
+	assert(!emu_ovl_cfg_find_item(&cfg, "nope", "rend.WideScreen", NULL, NULL));
+	assert(!emu_ovl_cfg_find_item(&cfg, "config", "nope", NULL, NULL));
+	// the global INI seeded current_value for every item
+	assert(item(&cfg, "config", "rend.WideScreen")->current_value == 0);
+	assert(item(&cfg, "achievements", "Enabled")->current_value == 1);
+	assert(item(&cfg, "network", "GGPODelay")->current_value == 0);
+	// types survived the JSON round-trip
+	assert(item(&cfg, "achievements", "Enabled")->type == EMU_OVL_TYPE_BOOL);
+	assert(item(&cfg, "network", "GGPODelay")->type == EMU_OVL_TYPE_CYCLE);
+	assert(item(&cfg, "network", "GGPODelay")->value_count == 6);
+	emu_ovl_cfg_free(&cfg);
+	printf("ok schema_loads\n");
+}
+
+// parse_value/format_value must agree with each other and with the INI
+// dialect emu.cfg + launch.sh's sed patterns expect.
+static void test_parse_and_format_value(void) {
+	EmuOvlConfig cfg;
+	OptsOverrideState st;
+	setup(&cfg, &st);
+	EmuOvlItem* b = item(&cfg, "config", "rend.WideScreen");
+	EmuOvlItem* c = item(&cfg, "network", "GGPODelay");
+	int v = -1;
+	char out[64];
+
+	// bool: flycast's yes/no and the overlay's own True/False both parse
+	assert(emu_ovl_cfg_parse_value(b, "yes", &v) && v == 1);
+	assert(emu_ovl_cfg_parse_value(b, "True", &v) && v == 1);
+	assert(emu_ovl_cfg_parse_value(b, "1", &v) && v == 1);
+	assert(emu_ovl_cfg_parse_value(b, "no", &v) && v == 0);
+	assert(emu_ovl_cfg_parse_value(b, "False", &v) && v == 0);
+	assert(!emu_ovl_cfg_parse_value(b, "", &v));
+
+	// numeric: garbage is rejected rather than silently becoming 0
+	assert(emu_ovl_cfg_parse_value(c, "3", &v) && v == 3);
+	assert(emu_ovl_cfg_parse_value(c, "-2", &v) && v == -2);
+	assert(!emu_ovl_cfg_parse_value(c, "abc", &v));
+	assert(!emu_ovl_cfg_parse_value(c, "", &v));
+	assert(!emu_ovl_cfg_parse_value(c, "3junk", &v));
+
+	// format matches what emu_ovl_cfg_write_ini has always written
+	emu_ovl_cfg_format_value(b, 1, out, sizeof(out));
+	assert(strcmp(out, "True") == 0);
+	emu_ovl_cfg_format_value(b, 0, out, sizeof(out));
+	assert(strcmp(out, "False") == 0);
+	emu_ovl_cfg_format_value(c, 4, out, sizeof(out));
+	assert(strcmp(out, "4") == 0);
+
+	// float_scale round-trips through both halves
+	c->float_scale = 100;
+	emu_ovl_cfg_format_value(c, 150, out, sizeof(out));
+	assert(strcmp(out, "1.500000") == 0);
+	assert(emu_ovl_cfg_parse_value(c, "1.5", &v) && v == 150);
+	c->float_scale = 0;
+
+	emu_ovl_cfg_free(&cfg);
+	printf("ok parse_and_format_value\n");
+}
+
+static void test_no_changes_no_file(void) {
+	EmuOvlConfig cfg;
+	OptsOverrideState st;
+	setup(&cfg, &st);
+	assert(opts_write_override(&cfg, &st, ROOT "/game.cfg") == 0);
+	assert(!file_exists(ROOT "/game.cfg"));
+	emu_ovl_cfg_free(&cfg);
+	printf("ok no_changes_no_file\n");
+}
+
+static void test_write_one_override(void) {
+	EmuOvlConfig cfg;
+	OptsOverrideState st;
+	setup(&cfg, &st);
+	item(&cfg, "config", "rend.WideScreen")->staged_value = 1;
+	assert(opts_write_override(&cfg, &st, ROOT "/game.cfg") == 1);
+	assert(file_exists(ROOT "/game.cfg"));
+	// re-read into a fresh config to prove the file round-trips
+	EmuOvlConfig cfg2;
+	OptsOverrideState st2;
+	memset(&cfg2, 0, sizeof(cfg2));
+	assert(emu_ovl_cfg_load(&cfg2, ROOT "/schema.json") == 0);
+	assert(emu_ovl_cfg_read_ini(&cfg2, ROOT "/emu.cfg") == 0);
+	opts_snapshot_globals(&cfg2, &st2);
+	assert(opts_read_override(&cfg2, &st2, ROOT "/game.cfg") == 1);
+	assert(item(&cfg2, "config", "rend.WideScreen")->current_value == 1);
+	assert(item(&cfg2, "config", "rend.WideScreen")->staged_value == 1);
+	int s = -1, i = -1;
+	emu_ovl_cfg_find_item(&cfg2, "config", "rend.WideScreen", &s, &i);
+	assert(st2.overridden[s][i]);
+	// the global baseline is untouched by the override layer
+	assert(st2.global_value[s][i] == 0);
+	// untouched items are not marked
+	emu_ovl_cfg_find_item(&cfg2, "achievements", "Enabled", &s, &i);
+	assert(!st2.overridden[s][i]);
+	emu_ovl_cfg_free(&cfg2);
+	emu_ovl_cfg_free(&cfg);
+	printf("ok write_one_override\n");
+}
+
+static void test_revert_to_global_unlinks(void) {
+	EmuOvlConfig cfg;
+	OptsOverrideState st;
+	setup(&cfg, &st);
+	item(&cfg, "config", "rend.WideScreen")->staged_value = 1;
+	assert(opts_write_override(&cfg, &st, ROOT "/game.cfg") == 1);
+	opts_commit(&cfg, &st);
+	// set it back to the global value -> file must disappear
+	item(&cfg, "config", "rend.WideScreen")->staged_value = 0;
+	assert(opts_write_override(&cfg, &st, ROOT "/game.cfg") == 0);
+	assert(!file_exists(ROOT "/game.cfg"));
+	// ...and the override marker clears on the next commit
+	opts_commit(&cfg, &st);
+	int s = -1, i = -1;
+	emu_ovl_cfg_find_item(&cfg, "config", "rend.WideScreen", &s, &i);
+	assert(!st.overridden[s][i]);
+	emu_ovl_cfg_free(&cfg);
+	printf("ok revert_to_global_unlinks\n");
+}
+
+static void test_ini_section_resolution(void) {
+	EmuOvlConfig cfg;
+	OptsOverrideState st;
+	setup(&cfg, &st);
+	item(&cfg, "achievements", "Enabled")->staged_value = 0; // global is yes(1)
+	item(&cfg, "network", "GGPODelay")->staged_value = 3;
+	assert(opts_write_override(&cfg, &st, ROOT "/game.cfg") == 2);
+	// file must use the RESOLVED ini_section names
+	FILE* f = fopen(ROOT "/game.cfg", "r");
+	assert(f);
+	char buf[512] = {0};
+	size_t n = fread(buf, 1, sizeof(buf) - 1, f);
+	buf[n] = '\0';
+	fclose(f);
+	assert(strstr(buf, "[achievements]"));
+	assert(strstr(buf, "[network]"));
+	assert(strstr(buf, "GGPODelay = 3"));
+	assert(strstr(buf, "Enabled = False"));
+	assert(!strstr(buf, "[config]")); // no unchanged section leaks in
+	emu_ovl_cfg_free(&cfg);
+	printf("ok ini_section_resolution\n");
+}
+
+static void test_malformed_override_ignored(void) {
+	EmuOvlConfig cfg;
+	OptsOverrideState st;
+	setup(&cfg, &st);
+	write_file(ROOT "/game.cfg", "not an ini at all\n= = =\n[unknown]\nfoo = bar\n");
+	assert(opts_read_override(&cfg, &st, ROOT "/game.cfg") == 0);
+	assert(item(&cfg, "config", "rend.WideScreen")->current_value == 0);
+	emu_ovl_cfg_free(&cfg);
+	printf("ok malformed_override_ignored\n");
+}
+
+// A known key carrying an unparseable value must leave the global value in
+// place instead of collapsing it to 0.
+static void test_unparseable_value_skipped(void) {
+	EmuOvlConfig cfg;
+	OptsOverrideState st;
+	setup(&cfg, &st);
+	write_file(ROOT "/game.cfg", "[network]\nGGPODelay = wat\n");
+	assert(opts_read_override(&cfg, &st, ROOT "/game.cfg") == 0);
+	int s = -1, i = -1;
+	emu_ovl_cfg_find_item(&cfg, "network", "GGPODelay", &s, &i);
+	assert(!st.overridden[s][i]);
+	emu_ovl_cfg_free(&cfg);
+	printf("ok unparseable_value_skipped\n");
+}
+
+// Comments, blank lines and pre-section keys are tolerated the same way
+// emu.cfg's own reader tolerates them.
+static void test_comments_and_blank_lines(void) {
+	EmuOvlConfig cfg;
+	OptsOverrideState st;
+	setup(&cfg, &st);
+	write_file(ROOT "/game.cfg",
+			   "# a comment\n"
+			   "; another\n"
+			   "GGPODelay = 5\n" // before any [section] -> ignored
+			   "\n"
+			   "[network]\n"
+			   "  GGPODelay  =  2  \n");
+	assert(opts_read_override(&cfg, &st, ROOT "/game.cfg") == 1);
+	assert(item(&cfg, "network", "GGPODelay")->current_value == 2);
+	emu_ovl_cfg_free(&cfg);
+	printf("ok comments_and_blank_lines\n");
+}
+
+static void test_missing_override_noop(void) {
+	EmuOvlConfig cfg;
+	OptsOverrideState st;
+	setup(&cfg, &st);
+	assert(opts_read_override(&cfg, &st, ROOT "/nope.cfg") == 0);
+	emu_ovl_cfg_free(&cfg);
+	printf("ok missing_override_noop\n");
+}
+
+static void test_commit_refreshes_marks(void) {
+	EmuOvlConfig cfg;
+	OptsOverrideState st;
+	setup(&cfg, &st);
+	item(&cfg, "network", "GGPODelay")->staged_value = 2;
+	assert(opts_write_override(&cfg, &st, ROOT "/game.cfg") == 1);
+	opts_commit(&cfg, &st);
+	int s = -1, i = -1;
+	emu_ovl_cfg_find_item(&cfg, "network", "GGPODelay", &s, &i);
+	assert(st.overridden[s][i]);
+	assert(item(&cfg, "network", "GGPODelay")->current_value == 2);
+	// commit must leave the global baseline alone so a later revert still
+	// compares against emu.cfg, not against the committed override
+	assert(st.global_value[s][i] == 0);
+	emu_ovl_cfg_free(&cfg);
+	printf("ok commit_refreshes_marks\n");
+}
+
+int main(void) {
+	test_schema_loads();
+	test_parse_and_format_value();
+	test_no_changes_no_file();
+	test_write_one_override();
+	test_revert_to_global_unlinks();
+	test_ini_section_resolution();
+	test_malformed_override_ignored();
+	test_unparseable_value_skipped();
+	test_comments_and_blank_lines();
+	test_missing_override_noop();
+	test_commit_refreshes_marks();
+	printf("all opts_override tests passed\n");
+	return 0;
+}

--- a/workspace/all/netplay-wizard/Makefile
+++ b/workspace/all/netplay-wizard/Makefile
@@ -1,0 +1,51 @@
+###########################################################
+
+ifeq (,$(PLATFORM))
+PLATFORM=$(UNION_PLATFORM)
+endif
+
+ifeq (,$(PLATFORM))
+	$(error please specify PLATFORM, eg. PLATFORM=trimui make)
+endif
+
+ifeq (,$(CROSS_COMPILE))
+	$(error missing CROSS_COMPILE for this toolchain)
+endif
+
+###########################################################
+
+include ../../$(PLATFORM)/platform/Makefile.env
+SDL?=SDL
+
+###########################################################
+
+TARGET = netplay
+# ../minarch/ is on the include path only for minarch.h: netplay/keyboard.c
+# includes it for the screen/sleep accessors, which wizard.c shims.
+INCDIR = -I. -I../common/ -I../netplay/ -I../minarch/ -I../../$(PLATFORM)/platform/
+include ../common/ui/ui.mk
+SOURCE = wizard.c wizard_wifi.c wizard_net.c wizard_sync.c \
+         ../netplay/wifi_direct.c ../netplay/network_common.c ../netplay/keyboard.c \
+         ../common/utils.c ../common/api.c ../common/audio_manager.c ../common/config.c ../common/scaler.c \
+         $(UI_COMPONENT_SRCS) $(UI_DIR)/ui_list.c \
+         ../../$(PLATFORM)/platform/platform.c
+
+CC = $(CROSS_COMPILE)gcc
+CFLAGS  += $(OPT)
+CFLAGS  += $(INCDIR) -I../../$(PLATFORM)/libmsettings -DPLATFORM=\"$(PLATFORM)\" -std=gnu99
+# HAS_WIFIMG is what selects the real WiFi/hotspot arms of the netplay sources
+# (netplay.c, netplay_helper.c, gbalink.c, gblink.c — their #else arm is "WiFi not
+# available on this platform"). wizard_wifi.c ports netplay_helper.c code without
+# carrying those #ifdefs (this target only builds for tg5040/tg5050, which have
+# WiFi), and none of the files in SOURCE tests the flag, so it is inert today —
+# kept as the build's statement of intent and for any netplay source added later.
+CFLAGS  += -DHAS_WIFIMG
+LDFLAGS	 += -L../../$(PLATFORM)/libmsettings -lmsettings -lSDL2_image -lSDL2_ttf -lm -ldl -lz -lpthread
+
+PRODUCT= build/$(PLATFORM)/$(TARGET).elf
+
+all:
+	mkdir -p build/$(PLATFORM)
+	$(CC) $(SOURCE) -o $(PRODUCT) $(CFLAGS) $(LDFLAGS)
+clean:
+	rm -rf build/

--- a/workspace/all/netplay-wizard/wizard.c
+++ b/workspace/all/netplay-wizard/wizard.c
@@ -1,0 +1,1028 @@
+/*
+ * netplay.elf — Dreamcast netplay pre-launch wizard.
+ *
+ * DC.pak's launch.sh runs this before flycast when nextui left the
+ * /tmp/netplay_launch flag. Role -> connection mode -> network set-up ->
+ * rendezvous, then a shell-sourceable session file for launch.sh.
+ *
+ * Exit codes are the launch.sh contract:
+ *   0 = session file written, start the game with netplay
+ *   1 = user cancelled, start the game normally
+ *   2 = usage/setup error, start the game normally
+ */
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+#include <stdbool.h>
+#include <msettings.h>
+
+#include "defines.h"
+#include "api.h"
+#include "config.h"
+#include "minarch.h"
+#include "ui_list.h"
+#include "ui_menubar.h"
+#include "ui_message.h"
+#include "ui_splash.h"
+#include "utils.h"
+#include "wifi_direct.h"
+#include "wizard.h"
+
+// How long a terminal message stays up before the process exits (ms).
+#define WIZ_MESSAGE_MS 1000
+
+typedef enum { ST_ROLE,
+			   ST_MODE,
+			   ST_NETSETUP,
+			   ST_RENDEZVOUS,
+			   ST_DONE } WizState;
+
+SDL_Surface* wiz_screen = NULL;
+
+// netplay/keyboard.c is linked for Task 3's password entry and reaches back
+// into minarch for the screen and the sleep hooks. The wizard has no core to
+// pause and no HDMI monitor, so only the screen accessor is real.
+SDL_Surface* minarch_getScreen(void) {
+	return wiz_screen;
+}
+void minarch_beforeSleep(void) {}
+void minarch_afterSleep(void) {}
+void minarch_hdmimon(void) {}
+
+//////////////////////////////////
+// CLI
+//////////////////////////////////
+
+// Split --fetch-files on commas. The patterns are matched against basenames
+// inside --fetch-to, so a '/' would let them escape that directory.
+static int parse_patterns(const char* csv, WizArgs* a) {
+	const char* p = csv;
+
+	while (*p) {
+		const char* comma = strchr(p, ',');
+		size_t len = comma ? (size_t)(comma - p) : strlen(p);
+
+		if (len > 0) {
+			if (a->pattern_count >= WIZ_MAX_PATTERNS) {
+				fprintf(stderr, "netplay: too many --fetch-files patterns (max %d)\n", WIZ_MAX_PATTERNS);
+				return -1;
+			}
+			if (len >= sizeof(a->patterns[0])) {
+				fprintf(stderr, "netplay: --fetch-files pattern too long\n");
+				return -1;
+			}
+			if (memchr(p, '/', len)) {
+				fprintf(stderr, "netplay: --fetch-files patterns must not contain '/'\n");
+				return -1;
+			}
+			memcpy(a->patterns[a->pattern_count], p, len);
+			a->patterns[a->pattern_count][len] = '\0';
+			a->pattern_count++;
+		}
+
+		if (!comma)
+			break;
+		p = comma + 1;
+	}
+
+	return 0;
+}
+
+static int parse_args(int argc, char** argv, WizArgs* a) {
+	memset(a, 0, sizeof(*a));
+	a->session_path = WIZ_SESSION_PATH_DEFAULT;
+
+	for (int i = 1; i < argc; i++) {
+		const char* arg = argv[i];
+		bool has_value = (i + 1 < argc);
+
+		if (strcmp(arg, "--cleanup") == 0) {
+			a->cleanup = true;
+		} else if (strcmp(arg, "--game") == 0 && has_value) {
+			a->game = argv[++i];
+		} else if (strcmp(arg, "--serve-dir") == 0 && has_value) {
+			a->serve_dir = argv[++i];
+		} else if (strcmp(arg, "--fetch-to") == 0 && has_value) {
+			a->fetch_to = argv[++i];
+		} else if (strcmp(arg, "--session-file") == 0 && has_value) {
+			a->session_path = argv[++i];
+		} else if (strcmp(arg, "--fetch-files") == 0 && has_value) {
+			if (parse_patterns(argv[++i], a) != 0)
+				return -1;
+		} else {
+			fprintf(stderr, "netplay: unknown or incomplete argument '%s'\n", arg);
+			return -1;
+		}
+	}
+
+	if (!a->cleanup && (!a->game || !a->game[0])) {
+		fprintf(stderr, "netplay: --game is required\n");
+		return -1;
+	}
+
+	return 0;
+}
+
+//////////////////////////////////
+// Session file
+//////////////////////////////////
+
+static void fput_shq(FILE* fp, const char* key, const char* val) {
+	fprintf(fp, "%s='", key);
+	for (const char* c = val; *c; c++)
+		if (*c == '\'')
+			fputs("'\\''", fp);
+		else
+			fputc(*c, fp);
+	fputs("'\n", fp);
+}
+
+int wizard_write_session(const char* path, const WizSession* s, const char* game) {
+	FILE* fp = fopen(path, "w");
+	if (!fp)
+		return -1;
+	fprintf(fp, "NETPLAY_ROLE=%s\nNETPLAY_PEER_IP=%s\nNETPLAY_MODE=%s\n",
+			s->role, s->peer_ip, s->mode);
+	fput_shq(fp, "NETPLAY_GAME", game);
+	fput_shq(fp, "NETPLAY_PREV_SSID", s->prev_ssid);
+
+	// A short write (tmpfs ENOSPC/EIO) must not read as success: exit 0 is the
+	// hard "start with netplay" contract, and launch.sh would then source a
+	// truncated file while --cleanup restored nothing. Errors surface at fclose
+	// as often as at fprintf, so check both.
+	int failed = (ferror(fp) != 0);
+	if (fclose(fp) != 0)
+		failed = 1;
+
+	if (failed) {
+		unlink(path);
+		return -1;
+	}
+
+	return 0;
+}
+
+// Reverse of fput_shq: drop the wrapping single quotes and turn '\'' back into
+// a literal quote. Not a shell parser — it only handles what fput_shq emits.
+static void shq_unescape(const char* src, char* out, size_t out_size) {
+	size_t o = 0;
+	const char* c = src;
+
+	if (*c == '\'')
+		c++;
+
+	while (*c && o + 1 < out_size) {
+		if (*c == '\'') {
+			if (c[1] == '\\' && c[2] == '\'' && c[3] == '\'') {
+				out[o++] = '\'';
+				c += 4;
+				continue;
+			}
+			break; // closing quote
+		}
+		out[o++] = *c++;
+	}
+
+	out[o] = '\0';
+}
+
+// Copy KEY=value into out when line starts with key. quoted = written by
+// fput_shq. Leaves out untouched on a non-match.
+static void take_key(const char* line, const char* key, char* out, size_t out_size, bool quoted) {
+	size_t klen = strlen(key);
+	if (strncmp(line, key, klen) != 0 || line[klen] != '=')
+		return;
+
+	const char* val = line + klen + 1;
+	if (quoted) {
+		shq_unescape(val, out, out_size);
+	} else {
+		strncpy(out, val, out_size - 1);
+		out[out_size - 1] = '\0';
+	}
+}
+
+// NETPLAY_GAME is written for launch.sh but not read back: WizSession has no
+// field for it and nothing on the cleanup path needs the title.
+//
+// Returns -1 for a missing file AND for one that yielded no role/mode: a
+// zero-byte or truncated session is indistinguishable from none as far as
+// teardown goes, and acting on half of one is worse than acting on nothing.
+int wizard_read_session(const char* path, WizSession* s) {
+	FILE* fp = fopen(path, "r");
+	if (!fp)
+		return -1;
+
+	memset(s, 0, sizeof(*s));
+
+	char line[512];
+	while (fgets(line, sizeof(line), fp)) {
+		int len = strlen(line);
+		while (len > 0 && (line[len - 1] == '\n' || line[len - 1] == '\r'))
+			line[--len] = '\0';
+
+		take_key(line, "NETPLAY_ROLE", s->role, sizeof(s->role), false);
+		take_key(line, "NETPLAY_PEER_IP", s->peer_ip, sizeof(s->peer_ip), false);
+		take_key(line, "NETPLAY_MODE", s->mode, sizeof(s->mode), false);
+		take_key(line, "NETPLAY_PREV_SSID", s->prev_ssid, sizeof(s->prev_ssid), true);
+	}
+
+	fclose(fp);
+
+	// Role and mode are what teardown dispatches on; without them there is no
+	// session, whatever the file contained.
+	if (!s->role[0] || !s->mode[0])
+		return -1;
+
+	return 0;
+}
+
+//////////////////////////////////
+// Teardown
+//////////////////////////////////
+//
+// Everything below undoes network state, and none of it draws: --cleanup runs
+// headless (no GFX_init, no SDL), so SDL_Delay() is usleep() here and the
+// callers that do have a screen draw their own message before calling in.
+
+// Hard ceiling on ONE teardown episode, measured from the entry point that
+// started it (--cleanup, the start-up heal, or a cancel arm) and covering
+// everything that follows, orphan AP stop included. The arithmetic in
+// wiz_teardown()'s header lands under this on every path; this is what makes
+// the bound hold anyway when a step overruns the estimate — which it did once
+// already, when the first version of that comment priced wifi_init.sh at zero.
+#define WIZ_TEARDOWN_BUDGET_MS 19000
+
+// WIFI_connectPass()'s own ceiling. It cannot be interrupted once entered, so
+// it is not started unless this much budget remains — otherwise the deadline
+// would be a suggestion rather than a bound.
+#define WIZ_CONNECT_WORST_MS 6000
+
+// wpa_supplicant does not answer the instant wifi_init.sh returns, and every
+// wpa_cli call in the reconnect would quietly fail until it does. Short,
+// because in both arms the supplicant is already there: on the host arm
+// wifi_init.sh start has just launched it (tg5050's script even verifies with
+// pidof before returning), and on the client arm it never stopped. This covers
+// the socket appearing after the process does, not a stack that is still coming
+// up from cold.
+#define WIZ_SUPPLICANT_TIMEOUT_MS 2000
+#define WIZ_SUPPLICANT_POLL_US 250000
+
+// How long the INTERACTIVE teardown waits for the reconnect's backgrounded
+// udhcpc to land a lease, and how often it looks. Only ever spent when
+// WIFI_connectPass() actually ran — see wiz_restore_prev_ssid().
+#define WIZ_RESTORE_SETTLE_MS 2000
+#define WIZ_RESTORE_POLL_MS 250
+
+// The CHEAP "is there an IPv4 address on wlan0" test: one shell, three procs.
+// Deliberately not WIFI_direct_getIP(), which goes through PLAT_wifiConnection
+// (generic_wifi.c:277-336) — a wpa_cli status, an ip/grep/cut pipeline and an
+// iw call, ~8 processes per look. At 250 ms polling that difference is seconds
+// of pure fork overhead inside a budget measured in seconds.
+#define WIZ_HAVE_IP_CMD "ip -4 addr show wlan0 2>/dev/null | grep -q 'inet '"
+
+// Monotonic milliseconds. NOT SDL_GetTicks(): --cleanup never initialises SDL.
+static uint32_t wiz_now_ms(void) {
+	struct timespec ts;
+
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	return (uint32_t)ts.tv_sec * 1000u + (uint32_t)(ts.tv_nsec / 1000000);
+}
+
+// Signed difference, so the comparison survives the uint32 wrap (same idiom as
+// wizard_sync.c:827).
+static bool wiz_past(uint32_t deadline) {
+	return (int32_t)(wiz_now_ms() - deadline) >= 0;
+}
+
+// Presence test for the AP address WIFI_direct_startHotspot() puts on wlan0.
+// Every byte is a compile-time constant (the address is wifi_direct.h's), and
+// wlan0 is the interface wifi_direct.c hosts on, hardcoded there for the same
+// single-radio reason. The trailing '/' is load-bearing: it is what stops
+// "inet 10.0.0.10/24" — a CLIENT's lease from a host's udhcpd, which serves
+// 10.0.0.10-50 — from reading as the host address 10.0.0.1.
+#define WIZ_HOTSPOT_IP_CMD \
+	"ip -4 addr show wlan0 2>/dev/null | grep -q 'inet " WIFI_DIRECT_HOTSPOT_IP "/'"
+
+static bool wiz_hostapd_running(void) {
+	return system("pidof hostapd > /dev/null 2>&1") == 0;
+}
+
+static bool wiz_hotspot_ip_present(void) {
+	return system(WIZ_HOTSPOT_IP_CMD) == 0;
+}
+
+/*
+ * A netplay AP that no session file accounts for — the STRICT test, BOTH marks.
+ *
+ * Used wherever nothing has said this device hosted: the two entry points
+ * (--cleanup and the start-up heal) run it before they even look for a session
+ * file, and the corrupt-session arm relies on that same call. Both marks are
+ * required because a lone hostapd could belong to the stock AP vif some
+ * firmware brings up at boot (wizard_wifi.c:569), which is not ours to kill;
+ * pairing it with an address test that is wlan0-specific and 10.0.0.1-specific
+ * excludes that vif (it lives on wlan1, wifi_direct.c:261/278) and excludes a
+ * client's 10.0.0.10-50 lease.
+ *
+ * WHAT THIS DELIBERATELY MISSES, stated because the loose test in
+ * wiz_stop_hotspot() catches it and this one does not: an AP whose hostapd
+ * CRASHED but whose address and udhcpd survive. Dropping the hostapd mark to
+ * catch it would make the test "10.0.0.1 is on wlan0", which fires on a home
+ * network that happened to lease this device 10.0.0.1 — a full WiFi-stack
+ * restart on a device that never went near netplay. A crashed hostapd is not
+ * broadcasting, so what it leaves behind is a stale address rather than a live
+ * AP; the false positive is the worse of the two, so this sacrifices the catch.
+ * wiz_stop_hotspot() can afford the loose test only because its caller already
+ * knows from the session file that this device hosted.
+ */
+static bool wiz_orphan_ap_present(void) {
+	return wiz_hostapd_running() && wiz_hotspot_ip_present();
+}
+
+/*
+ * Everything WIFI_direct_stopHotspot() does when its hotspot_active flag is
+ * true, for the case where that flag is false because ANOTHER PROCESS started
+ * the AP.
+ *
+ * The flag (wifi_direct.c:26) is process-local, and the wizard's teardown is
+ * usually not running in the process that hosted: `netplay.elf --cleanup` is a
+ * fresh process launch.sh starts after the game exits, and the start-up heal is
+ * the NEXT wizard. In both, WIFI_direct_stopHotspot() sees a false flag and
+ * returns 0 without touching a hostapd that is very much alive — the AP would
+ * outlive the session that created it, which is the one thing --cleanup exists
+ * to prevent.
+ *
+ * Mirror of wifi_direct.c:357-388, tmp-file names included; if that sequence
+ * changes, this one changes with it. The alternative — teaching
+ * WIFI_direct_stopHotspot() to treat a live hostapd as an active hotspot, which
+ * would delete this function — also changes behaviour for minarch's netplay.c,
+ * gblink.c and gbalink.c, and that is not this task's file to change.
+ */
+static void wiz_stop_hotspot_orphan(void) {
+	system("killall hostapd 2>/dev/null");
+	usleep(200000); // let hostapd release wlan0 (wifi_direct.c:364)
+	system("kill $(cat /tmp/gbalink_udhcpd.pid 2>/dev/null) 2>/dev/null");
+	system("killall udhcpd 2>/dev/null");
+
+	system("ip addr flush dev wlan0 2>/dev/null");
+	system("ip link set wlan0 down 2>/dev/null");
+	system("rm -f /tmp/gbalink_*.conf /tmp/gbalink_*.pid /tmp/gbalink_*.leases 2>/dev/null");
+
+	// Hands wlan0 back to the client stack: wifi_init.sh start restarts
+	// wpa_supplicant, which reassociates to a saved network on its own. Also
+	// what makes the CFG_init() in run_cleanup() mandatory — see there.
+	WIFI_enable(true);
+	usleep(500000);
+}
+
+// The host's half of a hotspot teardown, wherever it runs.
+static void wiz_stop_hotspot(void) {
+	// Whether the library call is about to do the work — and, because that flag
+	// is process-local, also the exact test for "this is the process that
+	// hosted". Captured BEFORE the call, which resets it.
+	bool was_ours = WIFI_direct_isHotspotActive();
+
+	// Does the whole job when was_ours. A no-op in every other process.
+	WIFI_direct_stopHotspot();
+
+	// !was_ours is load-bearing, not defensive. WIFI_direct_stopHotspot() ends
+	// in WIFI_enable(true) (wifi_direct.c:384), i.e. wifi_init.sh start — on a
+	// platform whose wifi_init brings up its own AP vif with a hostapd, probing
+	// afterwards would read state that call just CREATED, and the orphan stop
+	// would then kill the stock AP, down the wlan0 wpa_supplicant had just been
+	// given, and pay a second full stack restart. On the most-travelled path in
+	// this task (the in-wizard cancel). So the probe only ever runs in a process
+	// that did not host.
+	//
+	// There, EITHER mark is enough, because the caller already knows from the
+	// session file that this device hosted: a live hostapd is ours (startHotspot
+	// kills any other first, wifi_direct.c:273), and the AP address still on
+	// wlan0 means the client stack never came back even if hostapd has since
+	// died on its own — the case wiz_orphan_ap_present()'s strict test gives up.
+	if (!was_ours && (wiz_hostapd_running() || wiz_hotspot_ip_present()))
+		wiz_stop_hotspot_orphan();
+}
+
+/*
+ * Put the association back the way the wizard found it. "" = nothing to
+ * restore; note that the radio's POWER state is deliberately never restored
+ * (the ruling is recorded at wizard_wifi.c:160-168).
+ *
+ * WIFI_direct_connect() is NOT used here, and that is this function's whole
+ * shape. It ends in wifi_acquire_dhcp() (wifi_direct.c:38-61), which runs
+ * `udhcpc -i wlan0 -n -q -t 6` THREE times — with busybox's default -T 3 that
+ * is ~18 s per round against a network that does not answer, i.e. ~55 s of
+ * blocking DHCP on top of its own 10 s association poll. That is the right
+ * trade when JOINING a host's AP (the session cannot proceed without a lease,
+ * and someone is watching a progress screen), and the wrong one here: the
+ * session is over, and on --cleanup this runs on launch.sh's exit path with no
+ * screen at all, where it would read as a minute-long hang after the game quits.
+ *
+ * WIFI_connectPass() is the same association without the blocking DHCP: it
+ * polls at most 10 x 500 ms for the link (generic_wifi.c:664-685) and hands the
+ * lease to a BACKGROUNDED udhcpc (:681), which keeps working after this process
+ * exits. `interactive` then buys a bounded wait for that lease, and only where
+ * there is a screen to justify it.
+ */
+static void wiz_restore_prev_ssid(const char* ssid, bool interactive, uint32_t deadline) {
+	char current[WIFI_DIRECT_SSID_MAX];
+	bool connected = false;
+
+	if (!ssid || !ssid[0])
+		return;
+
+	// Bounded twice: by its own short timeout and by the episode's deadline.
+	for (uint32_t waited = 0; waited < WIZ_SUPPLICANT_TIMEOUT_MS && !wiz_past(deadline);
+		 waited += WIZ_SUPPLICANT_POLL_US / 1000) {
+		if (system("pidof wpa_supplicant > /dev/null 2>&1") == 0)
+			break;
+		usleep(WIZ_SUPPLICANT_POLL_US);
+	}
+
+	// Already there, and on the host arm this is the COMMON case rather than the
+	// lucky one: the AP teardown's wifi_init.sh spends ~9 s in a foreground
+	// udhcpc, and a wpa_supplicant with every saved network enabled reassociates
+	// during it. Otherwise: WiFi mode never left this network, or
+	// wizard_wifi.c's own failure paths (wiz_restore_connection at :213, the two
+	// WIFI_direct_restorePreviousConnection calls at :585/:593) already put it
+	// back. Reassociating to reach a state we are in already would only cost the
+	// game the wait.
+	if (WIFI_direct_getCurrentSSID(current, sizeof(current)) != 0 ||
+		strcmp(current, ssid) != 0) {
+		// Only with room for the whole call: WIFI_connectPass() cannot be
+		// interrupted once entered, so starting it with less than its own worst
+		// case left would let the episode overrun the deadline by up to 6 s.
+		// Skipping it is a graceful degradation rather than a failure — the
+		// supplicant this teardown restarted has every saved network enabled
+		// (select_network's disable is runtime-only and unsaved,
+		// generic_wifi.c:704-706), so it reassociates on its own; what is lost
+		// is determinism about WHICH saved network, not connectivity.
+		if (!wiz_past(deadline - WIZ_CONNECT_WORST_MS)) {
+			// NULL password = "use the saved network". VERIFIED, not assumed:
+			// generic_wifi.c:613 finds the EXISTING network id for this SSID and
+			// takes the "using existing network configuration" arm at :648 — the
+			// stored psk is left alone and the security argument is not read at
+			// all on that arm. prev_ssid is by construction a network this
+			// device was associated to (wizard_wifi.c:184-187 reads it from the
+			// connection info), so that entry exists. This is the same call
+			// WIFI_direct_connect() makes at wifi_direct.c:135, minus its DHCP.
+			//
+			// SECURITY_WPA2_PSK, not SECURITY_NONE, and only the FALLBACK arm
+			// can tell the difference: if wifi_find_network_id() returns -1 —
+			// the entry genuinely absent, or one transient `wpa_cli
+			// list_networks` failure — control reaches the add-branch, and there
+			// SECURITY_NONE would set key_mgmt NONE (:637-641) and save_config
+			// it, leaving a PERMANENT open twin of the user's home SSID that
+			// wpa_supplicant could then associate to on any open AP announcing
+			// that name. With WPA2_PSK neither sub-branch runs: the entry is
+			// added with no key material, cannot associate, and is inert. Same
+			// argument, same constant, as wifi_direct.c:235.
+			//
+			// The saved-network alternative,
+			// WIFI_direct_restorePreviousConnection(), cannot be used at all:
+			// the SSID it restores is process-local state (wifi_direct.c:28)
+			// that a cleanup process never wrote.
+			WIFI_connectPass(ssid, SECURITY_WPA2_PSK, NULL);
+			connected = true;
+		}
+	}
+
+	// WIFI_connectPass() runs select_network (generic_wifi.c:655), which
+	// disables every OTHER saved network for as long as the supplicant lives,
+	// and only undoes that on its success path (:674). An attempt that failed
+	// would otherwise leave the device unable to roam to any of its networks
+	// after the wizard is gone.
+	WIFI_enableAll();
+
+	// Interactive, and only when the call above actually ran. That gate is the
+	// point: WIFI_connectPass()'s backgrounded udhcpc is the ONLY lease-fetcher
+	// this function starts, so on the short-circuit path there is nothing to
+	// wait for — wifi_init.sh's own udhcpc has already either landed a lease or
+	// gone to the background to keep trying, and neither outcome is ours to
+	// block on.
+	//
+	// What the wait buys when it does run: a -2 sends the user back to the mode
+	// menu, and a retry that picks WiFi tests `isConnected() && have_ip()`
+	// (wizard_wifi.c:290) to skip the picker. It is the difference between that
+	// retry being instant and it showing a network list the user did not ask for
+	// — which is also why it is not spent headless, where nobody is retrying.
+	//
+	// A stale 10.0.0.x left over from a hotspot (see wiz_teardown()'s client
+	// arm) satisfies this probe and ends the wait early. Harmless: the wait is
+	// best-effort, so forfeiting it costs nothing and cannot hang anything.
+	if (interactive && connected) {
+		for (uint32_t waited = 0; waited < WIZ_RESTORE_SETTLE_MS && !wiz_past(deadline);
+			 waited += WIZ_RESTORE_POLL_MS) {
+			if (system(WIZ_HAVE_IP_CMD) == 0)
+				break;
+			usleep(WIZ_RESTORE_POLL_MS * 1000);
+		}
+	}
+}
+
+/*
+ * Undo the network state a session set up, as the session file describes it.
+ *
+ * Safe in a process that set none of it up and safe to call twice: every step
+ * either probes the device for what it is about to undo or is idempotent by
+ * construction.
+ *
+ * `interactive` = there is a screen in front of the user (the in-wizard cancel
+ * paths). False on --cleanup and on the start-up heal's own reclaim, where the
+ * only thing waiting is launch.sh.
+ *
+ * `deadline` is the episode's hard stop (WIZ_TEARDOWN_BUDGET_MS from the entry
+ * point, so an orphan AP stop the caller ran first is inside it too).
+ *
+ * LATENCY BUDGET. This blocks launch.sh's exit path with no UI when interactive
+ * is false, so the cost is stated rather than called "bounded". The dominant
+ * term is NOT in this file:
+ *
+ *   wiz_sync_serve_stop              ~0.1 s  3 forks, no waits
+ *   AP down + client stack back     ~10.0 s  200 ms + 500 ms of usleep, and
+ *   (host arm)                              between them WIFI_enable(true) =
+ *                                           wifi_init.sh start, which is
+ *                                           SYNCHRONOUS and ends in a
+ *                                           FOREGROUND `udhcpc -i wlan0 -b`
+ *                                           (tg5040 :27, tg5050 :79). wlan0 is
+ *                                           unassociated at that instant, so
+ *                                           that udhcpc only returns when
+ *                                           busybox backgrounds it ON LEASEFAIL
+ *                                           — ~9 s at the defaults (-t 3
+ *                                           discovers, -T 3 s apart). tg5050
+ *                                           adds ~0.5 s verifying its
+ *                                           wpa_supplicant start, up to 5 s if
+ *                                           that retries.
+ *     OR forgetAllHotspots (client)  ~0.5 s  4 wpa_cli round trips, no script
+ *   supplicant poll                 <=2.0 s  ~1 fork in practice; see the macro
+ *   WIFI_connectPass                <=6.0 s  10 x 500 ms assoc poll plus its
+ *                                           wpa_cli calls. DHCP is handed to a
+ *                                           BACKGROUNDED udhcpc, not waited on.
+ *                                           Skipped entirely with < 6 s left,
+ *                                           and skipped on the common host path
+ *                                           anyway (the supplicant reassociates
+ *                                           during that 9 s above).
+ *   WIFI_enableAll                  ~0.1 s
+ *   + IP settle                     <=2.3 s  interactive AND connectPass ran
+ *   -----------------------------------------------------------------------
+ *   headless client                 <=8.7 s
+ *   headless host, short-circuited  <=12.8 s
+ *   headless host, reconnecting     <=18.3 s
+ *   interactive host, reconnecting  <=20.6 s  -> CLAMPED to 19 s by `deadline`
+ *
+ * That last row is why the deadline exists rather than the arithmetic alone:
+ * the estimate above is the third one written for this function and the first
+ * two were wrong, in one case by pricing wifi_init.sh at zero. THE ASSUMPTION
+ * THE WHOLE TABLE RESTS ON is that busybox `udhcpc -b` backgrounds itself on
+ * leasefail instead of retrying in the foreground; if a platform ever ships a
+ * udhcpc that does not, wifi_init.sh start never returns and no deadline in
+ * this file can help, because the block is inside system(). That is the one
+ * thing to check on device.
+ *
+ * What used to make this ~70 s was WIFI_direct_connect()'s three blocking
+ * udhcpc rounds — see wiz_restore_prev_ssid(). Nothing here may reintroduce an
+ * unbounded wait: the wizard holds PWR_disablePowerOff, so a hang is one the
+ * user cannot even switch the device off out of.
+ */
+static void wiz_teardown(const WizSession* s, bool interactive, uint32_t deadline) {
+	// Unconditional, and the one part of this that is mandatory for --cleanup:
+	// the host's rsyncd is the only piece of the session that can outlive the
+	// wizard process. wizard_net.c stops it as soon as the client reports back,
+	// but a run killed mid-sync leaves it holding port 18731 and serving
+	// serve_dir to whoever asks. Idempotent when no daemon was ever started.
+	wiz_sync_serve_stop();
+
+	// WiFi mode set nothing up to undo: the picker left the device associated to
+	// a real network, which is exactly where it should stay.
+	if (strcmp(s->mode, "hotspot") != 0)
+		return;
+
+	if (strcmp(s->role, "host") == 0) {
+		wiz_stop_hotspot();
+	} else {
+		// Drops this session's NextUI-* entry (and any older one) and re-enables
+		// the saved networks the join's select_network left disabled.
+		//
+		// NOTE, so that nobody "fixes" the wrong end of it: this arm can leave a
+		// stale 10.0.0.x on wlan0. Nothing here flushes the interface, and the
+		// reconnect's lease comes from WIFI_connectPass()'s backgrounded udhcpc
+		// (generic_wifi.c:676-682), which — unlike wifi_acquire_dhcp()
+		// (wifi_direct.c:43-44) — does not flush the old address and routes
+		// first. Harmless, and deliberately left alone: the AP probes match
+		// "10.0.0.1/" exactly, so a client's 10.0.0.10-50 leftover cannot be
+		// read as a host AP. Widening those probes to the 10.0.0.x SUBNET to
+		// "catch" this would make every client teardown look like an orphaned
+		// AP and trigger a full WiFi-stack restart that nothing asked for.
+		WIFI_direct_forgetAllHotspots();
+	}
+
+	wiz_restore_prev_ssid(s->prev_ssid, interactive, deadline);
+}
+
+//////////////////////////////////
+// Cleanup mode (headless, no SDL)
+//////////////////////////////////
+
+// The teardown for a session file that is no longer live, shared by --cleanup
+// and by the start-up heal. Always leaves the file gone.
+//
+// BOTH callers run wiz_orphan_ap_present()/wiz_stop_hotspot_orphan() before
+// calling this, unconditionally, so an AP is already down by the time either
+// arm below runs — that hoist is what covers the session-less orphan, and it is
+// also what the corrupt arm here leans on instead of probing again.
+static void wiz_reclaim_session(const char* path, uint32_t deadline) {
+	// wizard_read_session only memsets after a successful fopen, so a failed
+	// read must not leave the caller looking at stack garbage.
+	WizSession session = {0};
+
+	if (wizard_read_session(path, &session) == 0) {
+		wiz_teardown(&session, false, deadline);
+	} else {
+		// No role and no mode to dispatch on: a write cut short by the same
+		// power loss that skipped the cleanup, or a file written by hand.
+		// Nothing here can know which network to restore, so what is left is
+		// the state that needs no session to justify undoing.
+		fprintf(stderr, "netplay: session file '%s' is unreadable; "
+						"undoing what the device still shows\n",
+				path);
+		wiz_sync_serve_stop();
+		// Cheap and never wrong: it only ever removes NextUI-*/GBLink-*/GBALink-*
+		// entries, which are single-session by construction, and re-enables the
+		// saved networks. There is no prev_ssid to restore, so the supplicant's
+		// own reassociation is what brings WiFi back.
+		WIFI_direct_forgetAllHotspots();
+	}
+
+	// Unconditional: a file that failed to parse has nothing to act on but must
+	// still not survive into the next launch.
+	if (unlink(path) != 0 && errno != ENOENT)
+		fprintf(stderr, "netplay: could not remove session file '%s': %s\n",
+				path, strerror(errno));
+}
+
+// ALWAYS returns 0. launch.sh runs this on its exit path, and a device that
+// could not be tidied up is no reason to fail the exit path of a game that has
+// already finished; problems go to stderr instead.
+static int run_cleanup(const WizArgs* a) {
+	bool have_session;
+	bool orphan_ap;
+	uint32_t deadline;
+
+	// BEFORE the session-file test, deliberately: a host killed mid-sync leaves
+	// an rsyncd holding port 18731 and serving serve_dir, and it leaves NO
+	// session file to find it by — wizard_net.c stops the daemon on every path
+	// it returns from, so only a kill escapes that, and the session file is
+	// written after the rendezvous rather than before it. Shell and files only,
+	// so unlike everything below it this is safe ahead of CFG_init(), and it is
+	// a no-op when no daemon was ever started.
+	wiz_sync_serve_stop();
+
+	have_session = (access(a->session_path, F_OK) == 0);
+
+	// The SAME argument, applied to the higher-stakes leak. The AP exists from
+	// wiz_hotspot_start() onwards, the session file only from ST_DONE, and the
+	// host's wait screen between them has no wall-clock ceiling by design
+	// (wizard_net.c:900-902). A host SIGKILLed in that window leaves hostapd,
+	// udhcpd, 10.0.0.1 on wlan0, a dead wpa_supplicant — and nothing naming any
+	// of it. The device cannot recover on its own either: hostapd holds wlan0
+	// IFF_UP, so the next run's WIFI_direct_ensureReady() (generic_wifi.c:127-138
+	// via wizard_wifi.c:169-180) believes the stack is fine and never restarts
+	// it. So this probe is NOT behind the session-file gate.
+	orphan_ap = wiz_orphan_ap_present();
+
+	// Two cheap system() probes and a missing file: the normal ending of every
+	// launch that did not use netplay, and of one that did and was cleaned up
+	// already. Nothing was left behind, so nothing below needs to run — not even
+	// CFG_init.
+	if (!have_session && !orphan_ap)
+		return 0;
+
+	// MANDATORY before any WIFI_* call below, and therefore above both of them.
+	// Both hotspot teardowns end in WIFI_enable(true) -> CFG_setWifi() ->
+	// CFG_sync(), which serialises config.c's in-memory settings over
+	// minuisettings.txt, merging every key it knows. In wizard mode GFX_init() ->
+	// CFG_init() (api.c:290) has loaded that struct from disk first; here nothing
+	// has, and syncing the all-zero definition (config.c:19) would silently reset
+	// every setting on the device. CFG_init() is the headless load — nextval.c:13
+	// and poweroff_next.c:338 use it exactly this way.
+	CFG_init(NULL, NULL);
+
+	// One budget for the whole episode, started before the orphan stop because
+	// that is where most of it goes (wifi_init.sh start, ~10 s).
+	deadline = wiz_now_ms() + WIZ_TEARDOWN_BUDGET_MS;
+
+	// Before the session teardown, not after: with the AP down, wlan0 is back
+	// with the client stack, which is what the reconnect inside
+	// wiz_reclaim_session() needs. A valid host session runs this arm too — its
+	// own wiz_stop_hotspot() then finds nothing left to do and goes straight on
+	// to restoring prev_ssid.
+	if (orphan_ap)
+		wiz_stop_hotspot_orphan();
+
+	if (have_session)
+		wiz_reclaim_session(a->session_path, deadline);
+
+	return 0;
+}
+
+//////////////////////////////////
+// Screens
+//////////////////////////////////
+
+#define WIZ_MENU_ITEMS 2
+
+static const char* role_items[] = {"Host Game", "Join Game"};
+static const char* mode_items[] = {"Hotspot", "WiFi"};
+
+static void render_role_menu(const char* game, int selected) {
+	SimpleMenuConfig config = {
+		.title = game,
+		.items = role_items,
+		.item_count = WIZ_MENU_ITEMS,
+		.btn_b_label = "CANCEL",
+		.hide_controls_hint = true};
+	UI_renderSimpleMenu(wiz_screen, selected, &config);
+	GFX_flip(wiz_screen);
+}
+
+static void render_mode_menu(int selected) {
+	SimpleMenuConfig config = {
+		.title = "Connection",
+		.items = mode_items,
+		.item_count = WIZ_MENU_ITEMS,
+		.btn_b_label = "BACK",
+		.hide_controls_hint = true};
+	UI_renderSimpleMenu(wiz_screen, selected, &config);
+
+	ListLayout layout = UI_calcListLayout(wiz_screen);
+	int y = layout.list_y + WIZ_MENU_ITEMS * layout.item_h + SCALE1(PADDING);
+	GFX_blitText(font.small, "Use hotspot for better gameplay", 0, COLOR_WHITE, wiz_screen,
+				 &(SDL_Rect){SCALE1(PADDING), y, layout.max_width, SCALE1(FONT_SMALL)});
+
+	GFX_flip(wiz_screen);
+}
+
+static void show_message(const char* message, int hold_ms) {
+	GFX_clear(wiz_screen);
+	UI_renderCenteredMessage(wiz_screen, message);
+	GFX_flip(wiz_screen);
+	SDL_Delay(hold_ms);
+}
+
+// Two-item menus: wrap rather than clamp. Returns true if the cursor moved.
+static bool menu_navigate(int* selected) {
+	if (PAD_justPressed(BTN_UP)) {
+		*selected = (*selected + WIZ_MENU_ITEMS - 1) % WIZ_MENU_ITEMS;
+		return true;
+	}
+	if (PAD_justPressed(BTN_DOWN)) {
+		*selected = (*selected + 1) % WIZ_MENU_ITEMS;
+		return true;
+	}
+	return false;
+}
+
+//////////////////////////////////
+// Wizard
+//////////////////////////////////
+
+/*
+ * The cancel/error teardown, and the only thing that clears `mode`.
+ *
+ * Clearing it is what keeps a -2 RETRY coherent. On a -2 the user lands back on
+ * the mode menu and may pick the other mode; until they do, the struct would
+ * otherwise still claim a hotspot that no longer exists, and anything that
+ * dispatched on it (the sweep after the loop) would tear the same session down
+ * a second time. ST_MODE always writes `mode` before ST_NETSETUP can read it,
+ * so clearing it costs the retry nothing.
+ *
+ * What deliberately survives:
+ *   role      the user is going back to the MODE menu, not the role menu;
+ *             ST_ROLE overwrites it if they walk back further.
+ *   prev_ssid a best-effort record, and after a teardown that reconnected it,
+ *             it names the network the device is on RIGHT NOW. It is not stale
+ *             either way: every entry into ST_NETSETUP re-reads the live SSID
+ *             before touching the association (wizard_wifi.c:282, :436, :472 all
+ *             call wiz_record_prev_ssid), so the retry captures the current
+ *             value and overwrites this one.
+ *   peer_ip   wizard_net.c's field; it clears it on its own failure paths.
+ *
+ * The message is drawn because the teardown blocks: a hotspot host teardown is a
+ * whole wifi_init.sh restart plus an association, up to the 19 s ceiling in
+ * wiz_teardown()'s budget, and without this the last screen would sit there
+ * looking hung. That screen is also what pays for the interactive flag — the
+ * extra wait it buys is the one a -2 retry benefits from.
+ */
+static void wiz_cancel(WizSession* s) {
+	show_message("Cleaning up...", 0);
+	wiz_teardown(s, true, wiz_now_ms() + WIZ_TEARDOWN_BUDGET_MS);
+	s->mode[0] = '\0';
+}
+
+int main(int argc, char* argv[]) {
+	WizArgs args;
+	if (parse_args(argc, argv, &args) != 0)
+		return 2;
+
+	if (args.cleanup)
+		return run_cleanup(&args);
+
+	wiz_screen = GFX_init(MODE_MAIN);
+	UI_showSplashScreen(wiz_screen, "Netplay");
+
+	PWR_pinToCores(CPU_CORE_EFFICIENCY);
+	InitSettings();
+	PAD_init();
+	PWR_init();
+	setup_signal_handlers();
+
+	// Discovery and save sync run unattended for minutes; keep the device up
+	// for the whole run (the process exits before the game starts).
+	PWR_disableSleep();
+	PWR_disableAutosleep();
+	PWR_disablePowerOff();
+
+	// A previous run that never reached --cleanup: an OSD kill or a flat battery
+	// takes launch.sh's exit path with it, and that run's AP (or its rsyncd) is
+	// still up. Undo it BEFORE this run sets anything up — wiz_hotspot_start()
+	// would otherwise stack an AP on an AP, and wiz_record_prev_ssid() would
+	// file the dead session's hotspot as the network to restore afterwards.
+	//
+	// Two independent pieces of evidence, and the AP probe is NOT gated on the
+	// session file for the reason spelled out in run_cleanup(): the AP outlives
+	// wiz_hotspot_start() while the file only appears at ST_DONE, so the window
+	// between them leaves an AP that nothing names. CFG_init() has already run
+	// here, inside GFX_init(), which is why this needs no equivalent of
+	// run_cleanup()'s.
+	bool stale_session = (access(args.session_path, F_OK) == 0);
+	bool orphan_ap = wiz_orphan_ap_present();
+
+	if (stale_session || orphan_ap) {
+		uint32_t deadline = wiz_now_ms() + WIZ_TEARDOWN_BUDGET_MS;
+
+		show_message("Cleaning up previous session...", 0);
+		if (orphan_ap)
+			wiz_stop_hotspot_orphan();
+		if (stale_session)
+			wiz_reclaim_session(args.session_path, deadline);
+	}
+
+	WizSession session;
+	memset(&session, 0, sizeof(session));
+
+	WizState state = ST_ROLE;
+	int role_selected = 0;
+	int mode_selected = 0;
+	// Anything that is not a completed session (including a signal) means
+	// "launch the game without netplay"; only ST_DONE clears this to 0.
+	int exit_code = 1;
+	bool dirty = true;
+	IndicatorType show_setting = INDICATOR_NONE;
+
+	while (!app_quit) {
+		GFX_startFrame();
+		PAD_poll();
+		PWR_update(&dirty, &show_setting, NULL, NULL);
+
+		if (UI_statusBarChanged())
+			dirty = true;
+
+		switch (state) {
+		case ST_ROLE:
+			if (menu_navigate(&role_selected)) {
+				dirty = true;
+			} else if (PAD_justPressed(BTN_A)) {
+				strcpy(session.role, role_selected == 0 ? "host" : "client");
+				state = ST_MODE;
+				dirty = true;
+			} else if (PAD_justPressed(BTN_B)) {
+				exit_code = 1;
+				app_quit = true;
+			}
+			break;
+
+		case ST_MODE:
+			if (menu_navigate(&mode_selected)) {
+				dirty = true;
+			} else if (PAD_justPressed(BTN_A)) {
+				strcpy(session.mode, mode_selected == 0 ? "hotspot" : "wifi");
+				state = ST_NETSETUP;
+				dirty = true;
+			} else if (PAD_justPressed(BTN_B)) {
+				state = ST_ROLE;
+				dirty = true;
+			}
+			break;
+
+		case ST_NETSETUP: {
+			bool is_host = (strcmp(session.role, "host") == 0);
+			int rc;
+
+			if (strcmp(session.mode, "hotspot") == 0)
+				rc = is_host ? wiz_hotspot_start(&session, args.game) : wiz_hotspot_join(&session);
+			else
+				rc = wiz_wifi_ensure_connected(&session);
+
+			// Both non-zero arms undo whatever got as far as being set up. A -2
+			// from the WiFi picker or the hotspot list has usually left nothing
+			// behind (each screen unwinds its own attempt before returning), but
+			// a -1 from wiz_hotspot_join() after it associated has: the NextUI-*
+			// network is saved by then.
+			if (rc == -2) {
+				wiz_cancel(&session);
+				state = ST_MODE;
+			} else if (rc != 0) {
+				wiz_cancel(&session);
+				exit_code = 2;
+				app_quit = true;
+			} else {
+				state = ST_RENDEZVOUS;
+			}
+			dirty = true;
+			break;
+		}
+
+		case ST_RENDEZVOUS: {
+			int rc = (strcmp(session.role, "host") == 0)
+						 ? wiz_host_rendezvous(&args, &session)
+						 : wiz_client_rendezvous(&args, &session);
+
+			// Both failure arms undo the ST_NETSETUP work first — by here a
+			// hotspot host has an AP up and both roles may have an rsyncd.
+			if (rc == -2) {
+				wiz_cancel(&session);
+				state = ST_MODE;
+			} else if (rc != 0) {
+				wiz_cancel(&session);
+				exit_code = 2;
+				app_quit = true;
+			} else {
+				state = ST_DONE;
+			}
+			dirty = true;
+			break;
+		}
+
+		case ST_DONE:
+			if (wizard_write_session(args.session_path, &session, args.game) != 0) {
+				show_message("Failed to write session file", WIZ_MESSAGE_MS);
+				// wizard_write_session() unlinks what it half-wrote, so
+				// launch.sh's --cleanup would find no session file and undo
+				// nothing (run_cleanup's first test) — the AP and the rsyncd
+				// would outlive a game that is about to start WITHOUT netplay.
+				// This is the last process that can take them down.
+				wiz_cancel(&session);
+				exit_code = 2;
+			} else {
+				show_message("Connected - starting game...", WIZ_MESSAGE_MS);
+				exit_code = 0;
+			}
+			app_quit = true;
+			break;
+		}
+
+		if (dirty) {
+			switch (state) {
+			case ST_ROLE:
+				render_role_menu(args.game, role_selected);
+				break;
+			case ST_MODE:
+				render_mode_menu(mode_selected);
+				break;
+			default:
+				break; // the network states draw their own screens
+			}
+			dirty = false;
+		} else {
+			GFX_sync();
+		}
+	}
+
+	// Anything that left the loop without going through wiz_cancel() still has
+	// whatever ST_NETSETUP set up: app_quit is what a caught signal sets, and
+	// wizard_net.c's wait screens turn it into a -2 that returns here with the
+	// loop condition already false. Only mode[0] can be true at this point,
+	// because wiz_cancel() is the one thing that clears it.
+	//
+	// exit_code 0 is the case that must be left alone: there the session file
+	// exists, the game is about to use it, and launch.sh's --cleanup is what
+	// takes it down afterwards. Still inside the PWR_disableSleep window, on
+	// purpose — the teardown blocks for as long as a reassociation takes.
+	if (exit_code != 0 && session.mode[0])
+		wiz_cancel(&session);
+
+	PWR_enableSleep();
+	PWR_enableAutosleep();
+
+	QuitSettings();
+	PWR_quit();
+	PAD_quit();
+	GFX_quit();
+
+	return exit_code;
+}

--- a/workspace/all/netplay-wizard/wizard.h
+++ b/workspace/all/netplay-wizard/wizard.h
@@ -1,0 +1,63 @@
+#ifndef WIZARD_H
+#define WIZARD_H
+
+#include <stdbool.h>
+
+#include "sdl.h"
+#include "network_common.h"
+
+#define WIZ_TCP_PORT 55440
+#define WIZ_UDP_PORT 55441
+#define WIZ_MAGIC 0x4E58575Au /* "NXWZ" — NextUI wizard */
+#define WIZ_PROTO_VERSION 1
+#define WIZ_RSYNC_PORT 18731
+#define WIZ_SESSION_PATH_DEFAULT "/tmp/netplay_session"
+#define WIZ_RSYNC_CONF "/tmp/netplay_rsyncd.conf"
+#define WIZ_RSYNC_PID "/tmp/netplay_rsyncd.pid"
+#define WIZ_RSYNC_LOG "/tmp/netplay_rsyncd.log"
+#define WIZ_MAX_PATTERNS 8
+
+typedef struct {
+	const char* game;					 // --game (required in wizard mode)
+	const char* serve_dir;				 // --serve-dir (optional; host offers sync)
+	const char* fetch_to;				 // --fetch-to (optional; client accepts sync)
+	char patterns[WIZ_MAX_PATTERNS][64]; // parsed --fetch-files
+	int pattern_count;
+	const char* session_path; // --session-file (default WIZ_SESSION_PATH_DEFAULT)
+	bool cleanup;			  // --cleanup
+} WizArgs;
+
+typedef struct {
+	char role[8]; // "host" | "client"
+	char peer_ip[16];
+	char mode[8];		// "hotspot" | "wifi"
+	char prev_ssid[33]; // SSID to restore on cleanup ("" = none)
+} WizSession;
+
+// All int returns below: 0 = ok, -1 = error (message already drawn by the
+// callee), -2 = user cancelled (B).
+
+// wizard.c
+// Owned by wizard.c's main(); the ported wifi/net/sync code draws on it.
+extern SDL_Surface* wiz_screen;
+
+int wizard_write_session(const char* path, const WizSession* s, const char* game);
+int wizard_read_session(const char* path, WizSession* s);
+
+// wizard_wifi.c (Task 3)
+// The hotspot SSID minus LINK_HOTSPOT_SSID_PREFIX, filled by wiz_hotspot_start()
+// and rendered on the host's waiting screen. Empty until then.
+extern char wiz_hotspot_code[8];
+
+int wiz_wifi_ensure_connected(WizSession* s);			// WiFi mode, both roles
+int wiz_hotspot_start(WizSession* s, const char* game); // hotspot host
+int wiz_hotspot_join(WizSession* s);					// hotspot client
+// wizard_net.c (Task 4)
+int wiz_host_rendezvous(const WizArgs* a, WizSession* s); // wait+handshake(+sync serve)
+int wiz_client_rendezvous(const WizArgs* a, WizSession* s);
+// wizard_sync.c (Task 5)
+int wiz_sync_serve_start(const char* serve_dir, const char* client_ip);
+void wiz_sync_serve_stop(void);
+int wiz_sync_pull(const char* host_ip, const char* fetch_to,
+				  char names[][64], int name_count);
+#endif

--- a/workspace/all/netplay-wizard/wizard_net.c
+++ b/workspace/all/netplay-wizard/wizard_net.c
@@ -1,0 +1,1308 @@
+/*
+ * Wizard rendezvous — UDP discovery, TCP control channel, handshake.
+ *
+ * One TCP control connection on WIZ_TCP_PORT carries newline-terminated ASCII
+ * lines; the host advertises itself on WIZ_UDP_PORT so the WiFi-mode client can
+ * list it. The exchange, in order:
+ *
+ *     client -> host:  HELLO 1 <game> client
+ *     host -> client:  HELLO 1 <game> host      (or REJECT <reason>, then close)
+ *     host -> client:  SYNC-READY <n>           (only when the host serves saves)
+ *     host -> client:  FILE <name>              (n times, bare filenames)
+ *     client -> host:  SYNC-DONE | SYNC-FAIL
+ *     host -> client:  START
+ *     client -> host:  START
+ *
+ * A space separates the fields, so a game title — and a save filename, same
+ * reason — travels with each space replaced by \x1f; see the wire protocol
+ * helpers. Every line stays parseable with one sscanf.
+ *
+ * A rejected or dropped client never ends the host's wait: the host closes that
+ * connection and returns to its waiting screen. The client is the side that
+ * gives up — back to its host list on WiFi, out of the wizard on hotspot.
+ */
+
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <fnmatch.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/select.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#include "api.h"
+#include "defines.h"
+#include "network_common.h"
+#include "ui_buttonhintbar.h"
+#include "ui_list.h"
+#include "ui_message.h"
+#include "utils.h"
+#include "wifi_direct.h"
+#include "wizard.h"
+
+// Longest control line accepted, terminator included. The longest line the
+// protocol can produce is "HELLO 1 <game> client" with a 255-char game token.
+#define WIZ_NET_LINE_MAX 512
+// Widest single token. The sscanf widths below are written out as literals
+// (a format string cannot interpolate a macro), so this and they must agree:
+// every "%255s" in this file is WIZ_NET_TOKEN_MAX - 1.
+#define WIZ_NET_TOKEN_MAX 256
+// wiz_sync_pull() takes char names[][64]; a name that does not fit is refused
+// rather than truncated.
+#define WIZ_NET_NAME_MAX 64
+#define WIZ_NET_SYNC_MAX_FILES 32
+// Field separator substitute. Filenames and game titles carry spaces; \x1f
+// (unit separator) is a control character, so neither can contain one.
+#define WIZ_NET_SPACE_ESC '\x1f'
+
+// Per-line ceiling on the control channel, as SO_RCVTIMEO and as the wall
+// clock the wait loops enforce.
+#define WIZ_NET_RECV_TIMEOUT_MS 5000
+// The client's pull runs outside this protocol (rsync, Task 5) and only reports
+// back when it is done, so its window is much wider than a line's.
+#define WIZ_NET_PULL_TIMEOUT_MS 30000
+#define WIZ_NET_CONNECT_TIMEOUT_MS 5000
+// Hotspot only: the AP has just come up, so the first SYN can be dropped.
+#define WIZ_NET_CONNECT_ATTEMPTS 3
+#define WIZ_NET_RETRY_DELAY_MS 1500
+#define WIZ_NET_BROADCAST_INTERVAL_US 1000000
+#define WIZ_NET_DISCOVERY_POLL_MS 500
+// Upper bound on a host list that never fills, mirroring wizard_wifi.c's
+// pickers: the wizard sits between the launcher and the game and must never
+// wait forever with nothing to pick.
+#define WIZ_NET_LIST_TIMEOUT_MS 120000
+#define WIZ_NET_ERROR_TIMEOUT_MS 5000
+#define WIZ_NET_NOTICE_MS 1500
+#define WIZ_NET_MAX_HOSTS NET_MAX_DISCOVERED_HOSTS
+#define WIZ_NET_LABEL_MAX 96
+// Discovery link_mode. Separates this wizard's broadcasts from any other user
+// of NET_sendDiscoveryBroadcast that might share the port.
+#define WIZ_NET_LINK_MODE "wizard"
+
+// Backstop for a peer that reports readable and then stalls mid-line: every
+// read here selects first, so this timeout should never be the one that fires.
+static const NET_TCPConfig WIZ_NET_TCP_CONFIG = {
+	.buffer_size = 65536,
+	.recv_timeout_us = WIZ_NET_RECV_TIMEOUT_MS * 1000,
+	.enable_keepalive = false};
+
+//////////////////////////////////
+// Screens
+//////////////////////////////////
+
+// wiz_net_status/wiz_net_error are deliberate twins of wizard_wifi.c's
+// wiz_status/wiz_error: same frames, same dismissal, file-local to each stage
+// of the wizard. Shared UI belongs in ../common/ui, which has no owner for
+// "full-screen wizard message" yet; keep the two in step until it does.
+static void wiz_net_status(const char* message) {
+	GFX_clear(wiz_screen);
+	UI_renderCenteredMessage(wiz_screen, message);
+	GFX_flip(wiz_screen);
+}
+
+// Terminal message. Auto-clears so a user who walked away is not left staring
+// at it — every caller either returns -1 (the wizard exits and the game starts)
+// or drops back to the host list.
+static void wiz_net_error(const char* message) {
+	GFX_clear(wiz_screen);
+	UI_renderCenteredMessage(wiz_screen, message);
+	UI_renderButtonHintBar(wiz_screen, (char*[]){"A", "OKAY", NULL});
+	GFX_flip(wiz_screen);
+
+	uint32_t start = SDL_GetTicks();
+	while (SDL_GetTicks() - start < WIZ_NET_ERROR_TIMEOUT_MS) {
+		GFX_startFrame();
+		PAD_poll();
+		if (PAD_justPressed(BTN_A) || PAD_justPressed(BTN_B))
+			break;
+		GFX_sync();
+	}
+}
+
+// Defined with the other wait loops below; the notice screen borrows it rather
+// than sleeping, so it obeys the same frame pacing as every other wait here.
+static int wiz_wait_ms(uint32_t ms, bool cancelable, const char* status);
+
+// Non-terminal flash: the host uses it on its way back to the waiting screen,
+// where a silent return would read as nothing having happened. An SDL_Delay
+// here would be the longest button-dead window in the file outside the
+// documented pull, with PWR_disablePowerOff held for the whole run.
+static void wiz_net_notice(const char* message) {
+	wiz_wait_ms(WIZ_NET_NOTICE_MS, false, message);
+}
+
+// GFX_blitText centres inside dst_rect, so a full-width rect at y is a centred
+// line at y.
+static void wiz_net_blit(TTF_Font* f, const char* text, int y) {
+	GFX_blitText(f, text, 0, COLOR_WHITE, wiz_screen,
+				 &(SDL_Rect){0, y, wiz_screen->w, SCALE1(FONT_LARGE)});
+}
+
+// The host's waiting screen: what the other player needs to type or know
+// (hotspot code / local IP) above the instruction and the status line.
+// Same three-tier layout as netplay_helper.c's hotspot/WiFi waiting screens.
+static void wiz_net_render_waiting(const char* big, const char* instruction, const char* status) {
+	int center_y = wiz_screen->h / 2;
+
+	GFX_clear(wiz_screen);
+	wiz_net_blit(font.large, big, center_y - SCALE1(FONT_LARGE + PADDING));
+	wiz_net_blit(font.medium, instruction, center_y + SCALE1(5));
+	wiz_net_blit(font.small, status, center_y + SCALE1(28));
+	UI_renderButtonHintBar(wiz_screen, (char*[]){"B", "CANCEL", NULL});
+	GFX_flip(wiz_screen);
+}
+
+// Message frame used while a control line is outstanding. cancelable drives the
+// hint only; the wait loop owns the button.
+static void wiz_net_render_wait_status(const char* message, bool cancelable) {
+	GFX_clear(wiz_screen);
+	UI_renderCenteredMessage(wiz_screen, message);
+	if (cancelable)
+		UI_renderButtonHintBar(wiz_screen, (char*[]){"B", "CANCEL", NULL});
+	GFX_flip(wiz_screen);
+}
+
+// Host list, windowed the same way as wizard_wifi.c's pickers:
+// UI_renderSimpleMenu draws every item it is handed, so the slice start is
+// passed as the item array.
+static void wiz_net_render_list(const char** labels, int count, int selected, int* scroll) {
+	ListLayout layout = UI_calcListLayout(wiz_screen);
+	UI_adjustListScroll(selected, scroll, layout.items_per_page);
+
+	int visible = count - *scroll;
+	if (visible > layout.items_per_page)
+		visible = layout.items_per_page;
+
+	SimpleMenuConfig config = {
+		.title = "Select Host",
+		.items = labels + *scroll,
+		.item_count = visible,
+		.btn_b_label = "BACK",
+		.hide_controls_hint = true};
+	UI_renderSimpleMenu(wiz_screen, selected - *scroll, &config);
+	UI_renderScrollIndicators(wiz_screen, *scroll, layout.items_per_page, count);
+	GFX_flip(wiz_screen);
+}
+
+static void wiz_net_render_empty(const char* message) {
+	SimpleMenuConfig config = {
+		.title = "Select Host",
+		.items = NULL,
+		.item_count = 0,
+		.btn_b_label = "BACK",
+		.hide_controls_hint = true};
+	UI_renderSimpleMenu(wiz_screen, 0, &config);
+	UI_renderCenteredMessage(wiz_screen, message);
+	GFX_flip(wiz_screen);
+}
+
+//////////////////////////////////
+// Wire protocol helpers
+//////////////////////////////////
+//
+// Pure text in, pure text out — no sockets, no SDL, no wizard state. Kept that
+// way on purpose: this is the half of the protocol that can be exercised on a
+// development host, and every parse below is fed by a remote peer.
+
+// Copies in to out with each space replaced by WIZ_NET_SPACE_ESC. Always
+// NUL-terminates; a value too long for out is truncated, which the receiver
+// then reads as a mismatch rather than as a shorter name.
+static void wiz_esc_spaces(const char* in, char* out, size_t out_size) {
+	size_t i = 0;
+
+	if (!out || out_size == 0)
+		return;
+
+	for (; in && in[i] && i + 1 < out_size; i++)
+		out[i] = (in[i] == ' ') ? WIZ_NET_SPACE_ESC : in[i];
+
+	out[i] = '\0';
+}
+
+// In-place inverse. Idempotent for a peer that sent no escapes at all, which is
+// what makes a space-free game title interoperable either way.
+static void wiz_unesc_spaces(char* s) {
+	for (; s && *s; s++)
+		if (*s == WIZ_NET_SPACE_ESC)
+			*s = ' ';
+}
+
+// 0 = parsed a syntactically valid HELLO. game/role come back still escaped.
+static int wiz_parse_hello(const char* line, int* version, char* game, size_t game_size,
+						   char* role, size_t role_size) {
+	char verb[16];
+	char game_tok[WIZ_NET_TOKEN_MAX];
+	char role_tok[16];
+	int ver = 0;
+
+	if (sscanf(line, "%15s %d %255s %15s", verb, &ver, game_tok, role_tok) != 4)
+		return -1;
+	if (strcmp(verb, "HELLO") != 0)
+		return -1;
+
+	*version = ver;
+	snprintf(game, game_size, "%s", game_tok);
+	snprintf(role, role_size, "%s", role_tok);
+	return 0;
+}
+
+// NULL = the peer is a match. Otherwise the REJECT reason, which is also the
+// key wiz_reject_message() turns into a sentence. Order matters: version is
+// checked first because a different version may not even mean the same thing by
+// "game" or "role".
+static const char* wiz_hello_mismatch(int version, const char* game, const char* role,
+									  const char* own_game, const char* expect_role) {
+	if (version != WIZ_PROTO_VERSION)
+		return "version";
+	if (!own_game || !game || strcmp(game, own_game) != 0)
+		return "game";
+	if (!role || strcmp(role, expect_role) != 0)
+		return "role";
+	return NULL;
+}
+
+// 0 = the line was a REJECT and reason holds its argument.
+static int wiz_parse_reject(const char* line, char* reason, size_t reason_size) {
+	char verb[16];
+	char reason_tok[32];
+
+	int fields = sscanf(line, "%15s %31s", verb, reason_tok);
+	if (fields < 1 || strcmp(verb, "REJECT") != 0)
+		return -1;
+
+	// A bare "REJECT" is legal on the wire; it just says nothing useful.
+	snprintf(reason, reason_size, "%s", fields == 2 ? reason_tok : "");
+	return 0;
+}
+
+// The user-facing half of a REJECT. Every reason is something the two devices
+// disagree on, so each line names the disagreement rather than the error.
+static const char* wiz_reject_message(const char* reason) {
+	if (!reason)
+		return "The host refused the connection.";
+	if (strcmp(reason, "version") == 0)
+		return "The host is running a\ndifferent netplay version.";
+	if (strcmp(reason, "game") == 0)
+		return "The host is running a\ndifferent game.";
+	if (strcmp(reason, "role") == 0)
+		return "Both devices are hosting.\n\nOne of them must join instead.";
+	if (strcmp(reason, "sync") == 0)
+		return "The host could not share\nits saves.";
+	return "The host refused the connection.";
+}
+
+// 0 = the line was SYNC-READY and n holds its count (unvalidated; the caller
+// bounds it against its own storage).
+static int wiz_parse_sync_ready(const char* line, int* n) {
+	char verb[16];
+	int count = 0;
+
+	if (sscanf(line, "%15s %d", verb, &count) != 2)
+		return -1;
+	if (strcmp(verb, "SYNC-READY") != 0)
+		return -1;
+
+	*n = count;
+	return 0;
+}
+
+// 0 = the line was FILE and name holds its still-escaped argument. name must be
+// at least WIZ_NET_TOKEN_MAX: a token wider than a filename may fit is read in
+// full so wiz_name_is_safe() can refuse it, rather than silently truncated into
+// a different, valid-looking name.
+static int wiz_parse_file(const char* line, char* name, size_t name_size) {
+	char verb[16];
+	char name_tok[WIZ_NET_TOKEN_MAX];
+
+	if (sscanf(line, "%15s %255s", verb, name_tok) != 2)
+		return -1;
+	if (strcmp(verb, "FILE") != 0)
+		return -1;
+
+	snprintf(name, name_size, "%s", name_tok);
+	return 0;
+}
+
+// A name the protocol may carry, in either direction. This is a WHITELIST, not
+// a list of things to reject: only [A-Za-z0-9._-] survives. Everything else —
+// every shell metacharacter, space, slash, quote, control byte, high byte — is
+// out by construction rather than by enumeration, so the rule cannot be
+// outgrown by a character nobody thought of.
+//
+// It has to be this strict because these names are remote input on their way to
+// wiz_sync_pull() (Task 5), and this repo's idiom for driving an external tool
+// is system() — wizard_wifi.c does it eight times, and so does the hotspot ping
+// below. A name like `id`.bin or a;id.bin passes --fetch-files happily
+// (fnmatch("*.bin", "a;id.bin", 0) == 0 — the pattern list is NOT a defence),
+// and would be LAN-triggerable command execution the moment it reached a shell.
+//
+// THIS IS THE WIRE-LEVEL GUARANTEE, NOT THE ONLY ONE. Task 5 must still treat
+// these names as data: posix_spawn/execv with no shell, or quoted. A whitelist
+// is the second line of defence, never a licence to interpolate.
+//
+// Rules the character class already subsumes, spelled out because they are the
+// reasons: '/' would leave the directory the peer does not choose; a space
+// would split one argv element into two; control characters (\n, \r, and
+// WIZ_NET_SPACE_ESC itself) would break the line framing or return from the
+// escape round trip as something else. Left explicit below: "."/".." (all
+// whitelisted characters, but still traversal), a leading '-' (whitelisted, but
+// rsync would read it as an option), and the length bound that
+// wiz_sync_pull()'s names[][64] imposes.
+//
+// Deliberately tighter than fnmatch allows. Dreamcast save names
+// (vmu_save_A1.bin, dc_nvmem.bin) fit comfortably; a name with a space is
+// refused rather than transferred, and symmetrically so — the host will not
+// offer it and the client will not accept it.
+//
+// Applied to the *decoded* name on both sides, so there is exactly one
+// canonical form that ever gets checked.
+static bool wiz_name_is_safe(const char* name) {
+	if (!name || !name[0])
+		return false;
+	if (strlen(name) >= WIZ_NET_NAME_MAX)
+		return false;
+	if (name[0] == '-')
+		return false;
+	if (strcmp(name, ".") == 0 || strcmp(name, "..") == 0)
+		return false;
+
+	// Explicit ranges, not isalnum(): that one is locale-dependent, and this
+	// rule must mean the same thing wherever it runs.
+	for (const char* c = name; *c; c++) {
+		if (*c >= 'A' && *c <= 'Z')
+			continue;
+		if (*c >= 'a' && *c <= 'z')
+			continue;
+		if (*c >= '0' && *c <= '9')
+			continue;
+		if (*c == '.' || *c == '_' || *c == '-')
+			continue;
+		return false;
+	}
+
+	return true;
+}
+
+// Pattern check against --fetch-files. Note what this is NOT: with FNM_PATHNAME
+// unset a '*' spans '/' and every metacharacter, so it constrains shape only —
+// wiz_name_is_safe() is what constrains content, and it runs first at both call
+// sites. No patterns means nothing is whitelisted; callers treat that as "this
+// side wants no files" rather than as "all files".
+static bool wiz_name_matches(const char* name, const char patterns[][64], int count) {
+	for (int i = 0; i < count; i++)
+		if (fnmatch(patterns[i], name, 0) == 0)
+			return true;
+	return false;
+}
+
+// Discovery packets carry the raw title in a fixed 64-byte field, so they need
+// no escaping — but a peer that escaped anyway must still match, and a title
+// longer than the field is truncated on the wire for both sides identically.
+static bool wiz_game_matches_broadcast(const char* broadcast_game, const char* own_game) {
+	char name[NET_MAX_GAME_NAME];
+
+	if (!broadcast_game || !own_game)
+		return false;
+
+	snprintf(name, sizeof(name), "%s", broadcast_game);
+	wiz_unesc_spaces(name);
+	return strncmp(name, own_game, NET_MAX_GAME_NAME - 1) == 0;
+}
+
+//////////////////////////////////
+// Control channel
+//////////////////////////////////
+
+// Lines arrive without regard for packet boundaries — the host emits
+// SYNC-READY and every FILE back to back, and TCP is free to deliver them in
+// one read. The reader keeps whatever came early instead of over-reading past a
+// line into the next one.
+typedef struct {
+	int fd;
+	char buf[WIZ_NET_LINE_MAX];
+	size_t len;
+} WizLineReader;
+
+static void wiz_reader_init(WizLineReader* r, int fd) {
+	r->fd = fd;
+	r->len = 0;
+}
+
+static bool wiz_fd_readable(int fd, int timeout_ms) {
+	fd_set fds;
+	struct timeval tv = {.tv_sec = timeout_ms / 1000, .tv_usec = (timeout_ms % 1000) * 1000};
+
+	if (fd < 0)
+		return false;
+
+	FD_ZERO(&fds);
+	FD_SET(fd, &fds);
+	return select(fd + 1, &fds, NULL, NULL, &tv) > 0;
+}
+
+// Non-blocking. 1 = a line was copied to out (terminator stripped), 0 = nothing
+// complete yet, -1 = the peer closed, errored, or sent a line too long to be
+// one of ours.
+static int wiz_reader_poll(WizLineReader* r, char* out, size_t out_size) {
+	while (1) {
+		char* nl = memchr(r->buf, '\n', r->len);
+		if (nl) {
+			size_t line_len = (size_t)(nl - r->buf);
+			size_t rest = r->len - line_len - 1;
+			size_t copy = line_len;
+
+			// Tolerate CRLF: a scripted peer (netcat, a test harness) is as
+			// likely to send it as not.
+			if (copy > 0 && r->buf[copy - 1] == '\r')
+				copy--;
+			if (copy >= out_size)
+				copy = out_size - 1;
+
+			memcpy(out, r->buf, copy);
+			out[copy] = '\0';
+
+			memmove(r->buf, nl + 1, rest);
+			r->len = rest;
+			return 1;
+		}
+
+		if (r->len == sizeof(r->buf))
+			return -1; // no terminator in a full buffer: not this protocol
+
+		if (!wiz_fd_readable(r->fd, 0))
+			return 0;
+
+		ssize_t got = recv(r->fd, r->buf + r->len, sizeof(r->buf) - r->len, 0);
+		if (got == 0)
+			return -1; // orderly close
+		if (got < 0) {
+			if (errno == EINTR)
+				continue;
+			if (errno == EAGAIN || errno == EWOULDBLOCK)
+				return 0;
+			return -1;
+		}
+
+		r->len += (size_t)got;
+	}
+}
+
+// MSG_NOSIGNAL is load-bearing: setup_signal_handlers() leaves SIGPIPE at its
+// default, so writing to a peer that vanished would kill the wizard outright
+// and launch.sh would see a signal, not one of its exit codes.
+static int wiz_write_all(int fd, const char* buf, size_t len) {
+	size_t sent = 0;
+
+	while (sent < len) {
+		ssize_t n = send(fd, buf + sent, len - sent, MSG_NOSIGNAL);
+		if (n < 0) {
+			if (errno == EINTR)
+				continue;
+			return -1;
+		}
+		sent += (size_t)n;
+	}
+
+	return 0;
+}
+
+static int wiz_send_line(int fd, const char* fmt, ...) {
+	char line[WIZ_NET_LINE_MAX];
+	va_list ap;
+
+	va_start(ap, fmt);
+	int len = vsnprintf(line, sizeof(line) - 1, fmt, ap);
+	va_end(ap);
+
+	if (len < 0)
+		return -1;
+	if (len > (int)sizeof(line) - 2)
+		len = (int)sizeof(line) - 2; // truncated; the peer will reject it
+
+	line[len] = '\n';
+	line[len + 1] = '\0';
+	return wiz_write_all(fd, line, (size_t)len + 1);
+}
+
+// The one wait primitive for the control channel. Runs the frame loop so the
+// power button, the battery indicator and (when cancelable) B stay live while a
+// line is outstanding — a blocking recv would freeze all three for its timeout.
+// 0 = line in out, -1 = timeout/close/protocol error, -2 = cancelled.
+static int wiz_wait_line(WizLineReader* r, char* out, size_t out_size,
+						 uint32_t timeout_ms, bool cancelable, const char* status) {
+	uint32_t start = SDL_GetTicks();
+	bool dirty = true;
+
+	while (1) {
+		GFX_startFrame();
+		PAD_poll();
+
+		if (cancelable && (PAD_justPressed(BTN_B) || app_quit))
+			return -2;
+
+		int rc = wiz_reader_poll(r, out, out_size);
+		if (rc == 1)
+			return 0;
+		if (rc < 0)
+			return -1;
+
+		if (SDL_GetTicks() - start >= timeout_ms)
+			return -1;
+
+		PWR_update(&dirty, NULL, NULL, NULL);
+
+		if (dirty) {
+			wiz_net_render_wait_status(status, cancelable);
+			dirty = false;
+		} else {
+			GFX_sync();
+		}
+	}
+}
+
+// Frame-paced sleep. Same reason as wiz_wait_line: an SDL_Delay here would sit
+// on the retry gap with the buttons dead. 0 = waited, -2 = cancelled.
+static int wiz_wait_ms(uint32_t ms, bool cancelable, const char* status) {
+	uint32_t start = SDL_GetTicks();
+	bool dirty = true;
+
+	while (SDL_GetTicks() - start < ms) {
+		GFX_startFrame();
+		PAD_poll();
+
+		if (cancelable && (PAD_justPressed(BTN_B) || app_quit))
+			return -2;
+
+		PWR_update(&dirty, NULL, NULL, NULL);
+
+		if (dirty) {
+			wiz_net_render_wait_status(status, cancelable);
+			dirty = false;
+		} else {
+			GFX_sync();
+		}
+	}
+
+	return 0;
+}
+
+// Non-blocking connect driven from the frame loop. A blocking connect() cannot
+// be bounded portably (SO_SNDTIMEO is not specified to apply to it) and would
+// hold the UI for the whole SYN retransmit window, which on a hotspot that has
+// just come up is most of the interesting case.
+// 0 = connected (*out_fd owned by the caller), -1 = failed, -2 = cancelled.
+static int wiz_connect(const char* ip, uint16_t port, uint32_t timeout_ms,
+					   const char* status, int* out_fd) {
+	struct sockaddr_in addr = {0};
+	uint32_t start;
+	bool dirty = true;
+	int flags;
+
+	*out_fd = -1;
+
+	int fd = socket(AF_INET, SOCK_STREAM, 0);
+	if (fd < 0)
+		return -1;
+
+	addr.sin_family = AF_INET;
+	addr.sin_port = htons(port);
+	if (inet_pton(AF_INET, ip, &addr.sin_addr) <= 0) {
+		close(fd);
+		return -1;
+	}
+
+	flags = fcntl(fd, F_GETFL, 0);
+	fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+
+	int rc = connect(fd, (struct sockaddr*)&addr, sizeof(addr));
+	if (rc < 0 && errno != EINPROGRESS) {
+		close(fd);
+		return -1;
+	}
+
+	start = SDL_GetTicks();
+	while (rc != 0) {
+		fd_set wfds;
+		struct timeval tv = {0, 0};
+
+		GFX_startFrame();
+		PAD_poll();
+
+		if (PAD_justPressed(BTN_B) || app_quit) {
+			close(fd);
+			return -2;
+		}
+
+		FD_ZERO(&wfds);
+		FD_SET(fd, &wfds);
+
+		int sel = select(fd + 1, NULL, &wfds, NULL, &tv);
+		if (sel > 0) {
+			// Writable covers both outcomes; SO_ERROR says which.
+			int err = 0;
+			socklen_t err_len = sizeof(err);
+			if (getsockopt(fd, SOL_SOCKET, SO_ERROR, &err, &err_len) < 0 || err != 0) {
+				close(fd);
+				return -1;
+			}
+			break;
+		}
+		if (sel < 0 && errno != EINTR) {
+			close(fd);
+			return -1;
+		}
+		if (SDL_GetTicks() - start >= timeout_ms) {
+			close(fd);
+			return -1;
+		}
+
+		PWR_update(&dirty, NULL, NULL, NULL);
+
+		if (dirty) {
+			wiz_net_render_wait_status(status, true);
+			dirty = false;
+		} else {
+			GFX_sync();
+		}
+	}
+
+	// Back to blocking for the handshake: reads go through select() first, and
+	// WIZ_NET_TCP_CONFIG's SO_RCVTIMEO is what covers the gap between the two.
+	fcntl(fd, F_SETFL, flags);
+	NET_configureTCPSocket(fd, &WIZ_NET_TCP_CONFIG);
+
+	*out_fd = fd;
+	return 0;
+}
+
+//////////////////////////////////
+// Host
+//////////////////////////////////
+
+// Entries of serve_dir that --fetch-files selects, as bare names. Returns the
+// count (0 when there is nothing to offer, which skips the sync phase entirely).
+static int wiz_collect_serve_files(const WizArgs* a, char names[][WIZ_NET_NAME_MAX]) {
+	DIR* dir = opendir(a->serve_dir);
+	int n = 0;
+
+	if (!dir)
+		return 0;
+
+	struct dirent* entry;
+	while (n < WIZ_NET_SYNC_MAX_FILES && (entry = readdir(dir)) != NULL) {
+		char path[512];
+		struct stat st;
+
+		if (!wiz_name_is_safe(entry->d_name))
+			continue;
+		if (!wiz_name_matches(entry->d_name, a->patterns, a->pattern_count))
+			continue;
+
+		// Regular files only: the protocol offers one name per file and the
+		// client pulls them individually, which a directory would not survive.
+		snprintf(path, sizeof(path), "%s/%s", a->serve_dir, entry->d_name);
+		if (stat(path, &st) != 0 || !S_ISREG(st.st_mode))
+			continue;
+
+		snprintf(names[n], WIZ_NET_NAME_MAX, "%s", entry->d_name);
+		n++;
+	}
+
+	closedir(dir);
+	return n;
+}
+
+// Offer n files and wait for the client to finish pulling them.
+// 0 = pulled, 1 = give this client up and go back to waiting, -1 = fatal.
+static int wiz_host_serve(const WizArgs* a, WizSession* s, int fd, WizLineReader* r,
+						  char names[][WIZ_NET_NAME_MAX], int n) {
+	char line[WIZ_NET_LINE_MAX];
+	char escaped[WIZ_NET_TOKEN_MAX];
+	bool ok;
+
+	if (wiz_sync_serve_start(a->serve_dir, s->peer_ip) != 0) {
+		// Tell the client why before dropping it; it has nothing else to go on.
+		wiz_send_line(fd, "REJECT sync");
+		wiz_net_error("Could not share saves.\n\nPlease try again.");
+		return -1;
+	}
+
+	ok = (wiz_send_line(fd, "SYNC-READY %d", n) == 0);
+	for (int i = 0; ok && i < n; i++) {
+		wiz_esc_spaces(names[i], escaped, sizeof(escaped));
+		ok = (wiz_send_line(fd, "FILE %s", escaped) == 0);
+	}
+
+	if (!ok) {
+		wiz_sync_serve_stop();
+		return 1;
+	}
+
+	// B is off for this window on purpose: the client is mid-pull and tearing
+	// the server down under it would leave half a save directory. A client that
+	// dropped shows up as the wait timing out.
+	int rc = wiz_wait_line(r, line, sizeof(line), WIZ_NET_PULL_TIMEOUT_MS, false, "Sending saves...");
+	wiz_sync_serve_stop();
+
+	if (rc != 0 || strcmp(line, "SYNC-DONE") != 0) {
+		wiz_net_notice("Save transfer failed.\n\nWaiting for another player...");
+		return 1;
+	}
+
+	return 0;
+}
+
+// One accepted connection, start to finish. fd stays owned by the caller.
+// 0 = rendezvous complete, 1 = not our peer / dropped, keep waiting,
+// -1 = fatal (message drawn), -2 = cancelled.
+static int wiz_host_session(const WizArgs* a, WizSession* s, int fd,
+							const struct sockaddr_in* peer) {
+	WizLineReader reader;
+	char line[WIZ_NET_LINE_MAX];
+	char status[96];
+	char peer_ip[16] = {0};
+	char game[WIZ_NET_TOKEN_MAX];
+	char escaped[WIZ_NET_TOKEN_MAX];
+	char role[16];
+	int version = 0;
+
+	// Linux does not pass O_NONBLOCK from the listening fd to the accepted one,
+	// but POSIX leaves that unspecified and the listener is now non-blocking, so
+	// say it outright: wiz_write_all() has no EAGAIN path, and reads here want
+	// the blocking + SO_RCVTIMEO pairing that WIZ_NET_TCP_CONFIG sets up.
+	int peer_flags = fcntl(fd, F_GETFL, 0);
+	if (peer_flags >= 0)
+		fcntl(fd, F_SETFL, peer_flags & ~O_NONBLOCK);
+
+	NET_configureTCPSocket(fd, &WIZ_NET_TCP_CONFIG);
+	wiz_reader_init(&reader, fd);
+
+	if (!inet_ntop(AF_INET, &peer->sin_addr, peer_ip, sizeof(peer_ip)))
+		return 1;
+
+	snprintf(status, sizeof(status), "Player connected\n%s", peer_ip);
+
+	int rc = wiz_wait_line(&reader, line, sizeof(line), WIZ_NET_RECV_TIMEOUT_MS, true, status);
+	if (rc == -2)
+		return -2;
+	if (rc != 0)
+		return 1; // no HELLO in time: not worth a reply
+
+	if (wiz_parse_hello(line, &version, game, sizeof(game), role, sizeof(role)) != 0)
+		return 1; // not a wizard peer at all; closing says it better than REJECT
+
+	wiz_unesc_spaces(game);
+
+	const char* reason = wiz_hello_mismatch(version, game, role, a->game, "client");
+	if (reason) {
+		// Rejecting is not an error here — the host keeps waiting for the peer
+		// it is actually paired with.
+		wiz_send_line(fd, "REJECT %s", reason);
+		return 1;
+	}
+
+	wiz_esc_spaces(a->game, escaped, sizeof(escaped));
+	if (wiz_send_line(fd, "HELLO %d %s host", WIZ_PROTO_VERSION, escaped) != 0)
+		return 1;
+
+	snprintf(s->peer_ip, sizeof(s->peer_ip), "%s", peer_ip);
+
+	if (a->serve_dir) {
+		char names[WIZ_NET_SYNC_MAX_FILES][WIZ_NET_NAME_MAX];
+		int n = wiz_collect_serve_files(a, names);
+
+		// Nothing to offer means no sync phase at all: the client reads the next
+		// line either way, and starting a file server for zero files is waste.
+		if (n > 0) {
+			int src = wiz_host_serve(a, s, fd, &reader, names, n);
+			if (src != 0) {
+				s->peer_ip[0] = '\0';
+				return src;
+			}
+		}
+	}
+
+	if (wiz_send_line(fd, "START") != 0) {
+		s->peer_ip[0] = '\0';
+		return 1;
+	}
+
+	rc = wiz_wait_line(&reader, line, sizeof(line), WIZ_NET_RECV_TIMEOUT_MS, true, "Starting...");
+	if (rc == -2) {
+		s->peer_ip[0] = '\0';
+		return -2;
+	}
+	if (rc != 0 || strcmp(line, "START") != 0) {
+		s->peer_ip[0] = '\0';
+		wiz_net_notice("The other device did not start.\n\nWaiting for another player...");
+		return 1;
+	}
+
+	return 0;
+}
+
+int wiz_host_rendezvous(const WizArgs* a, WizSession* s) {
+	NET_BroadcastTimer broadcast_timer;
+	char error_text[128] = {0};
+	char big[64];
+	bool hotspot = (strcmp(s->mode, "hotspot") == 0);
+	bool dirty = true;
+	int result = -1;
+
+	int listen_fd = NET_createListenSocket(WIZ_TCP_PORT, error_text, sizeof(error_text));
+	if (listen_fd < 0) {
+		char message[192];
+		snprintf(message, sizeof(message), "Could not host.\n\n%s", error_text);
+		wiz_net_error(message);
+		return -1;
+	}
+
+	// NET_createListenSocket leaves the fd blocking, and select() reporting it
+	// readable is NOT a promise that accept() will not block: if the peer resets
+	// the connection in the gap between the two, Linux drops it from the queue
+	// and a blocking accept() waits for the *next* one, which may never come.
+	// That hangs this thread — no PAD_poll, no timeout — while wizard.c holds
+	// PWR_disableSleep/Autosleep/PowerOff, i.e. a device the user can neither
+	// cancel nor switch off. Non-blocking turns that case into an EAGAIN the
+	// accept loop below already ignores.
+	int listen_flags = fcntl(listen_fd, F_GETFL, 0);
+	if (listen_flags >= 0)
+		fcntl(listen_fd, F_SETFL, listen_flags | O_NONBLOCK);
+
+	// Discovery is how the WiFi client finds us; the hotspot client already
+	// knows the address. A socket we could not create is therefore not fatal in
+	// hotspot mode and only costs the list entry in WiFi mode.
+	int udp_fd = NET_createBroadcastSocket();
+	NET_initBroadcastTimer(&broadcast_timer, WIZ_NET_BROADCAST_INTERVAL_US);
+
+	if (hotspot) {
+		snprintf(big, sizeof(big), "%s", wiz_hotspot_code[0] ? wiz_hotspot_code : "????");
+	} else {
+		char ip[16] = {0};
+		if (WIFI_direct_getIP(ip, sizeof(ip)) != 0 || !ip[0])
+			NET_getLocalIP(ip, sizeof(ip));
+		snprintf(big, sizeof(big), "%s", ip[0] ? ip : "0.0.0.0");
+	}
+
+	const char* instruction = hotspot ? "Select this code on the other device"
+									  : "Other device must be on the same WiFi";
+
+	// No wall-clock ceiling: this screen exists to wait for a person, and B is
+	// live every frame. wizard.c holds sleep/power-off off for the whole run,
+	// so an abandoned host waits until the battery decides otherwise.
+	while (1) {
+		GFX_startFrame();
+		PAD_poll();
+
+		if (PAD_justPressed(BTN_B) || app_quit) {
+			result = -2;
+			break;
+		}
+
+		if (udp_fd >= 0 && NET_shouldBroadcast(&broadcast_timer))
+			NET_sendDiscoveryBroadcast(udp_fd, WIZ_MAGIC, WIZ_PROTO_VERSION, 0 /* crc unused */,
+									   WIZ_TCP_PORT, WIZ_UDP_PORT, a->game, WIZ_NET_LINK_MODE);
+
+		if (wiz_fd_readable(listen_fd, 0)) {
+			struct sockaddr_in peer = {0};
+			socklen_t peer_len = sizeof(peer);
+
+			// A failure here is EAGAIN/EWOULDBLOCK (the reset-in-the-gap case the
+			// O_NONBLOCK above exists for) or a transient errno; either way it
+			// just means no client this frame.
+			int peer_fd = accept(listen_fd, (struct sockaddr*)&peer, &peer_len);
+			if (peer_fd >= 0) {
+				int rc = wiz_host_session(a, s, peer_fd, &peer);
+				close(peer_fd);
+
+				if (rc != 1) {
+					result = rc;
+					break;
+				}
+				dirty = true; // rejected or dropped: waiting screen again
+			}
+		}
+
+		PWR_update(&dirty, NULL, NULL, NULL);
+
+		if (dirty) {
+			wiz_net_render_waiting(big, instruction, "Waiting for player...");
+			dirty = false;
+		} else {
+			GFX_sync();
+		}
+	}
+
+	if (udp_fd >= 0)
+		close(udp_fd);
+	close(listen_fd);
+	return result;
+}
+
+//////////////////////////////////
+// Client
+//////////////////////////////////
+
+// Live list of hosts broadcasting our game. 0 = ip_out filled, -1 = error
+// (message drawn), -2 = cancelled.
+static int wiz_client_pick_host(const WizArgs* a, char* ip_out, size_t ip_size) {
+	NET_HostInfo hosts[WIZ_NET_MAX_HOSTS];
+	char label_text[WIZ_NET_MAX_HOSTS][WIZ_NET_LABEL_MAX];
+	const char* labels[WIZ_NET_MAX_HOSTS];
+	int matches[WIZ_NET_MAX_HOSTS];
+	int host_count = 0; // every host seen, our game or not
+	int match_count = 0;
+	int selected = 0;
+	int scroll = 0;
+	bool dirty = true;
+	uint32_t last_poll = 0;
+	uint32_t start_time = SDL_GetTicks();
+
+	int udp_fd = NET_createDiscoveryListenSocket(WIZ_UDP_PORT);
+	if (udp_fd < 0) {
+		wiz_net_error("Could not listen for hosts.\n\nPlease try again.");
+		return -1;
+	}
+
+	while (1) {
+		uint32_t now = SDL_GetTicks();
+
+		// Only while there is nothing to pick, as in wizard_wifi.c's hotspot
+		// picker: once a host is listed the choice is the user's to take.
+		if (match_count == 0 && now - start_time > WIZ_NET_LIST_TIMEOUT_MS) {
+			close(udp_fd);
+			wiz_net_error("No host found.\n\nMake sure the host has\nstarted hosting first.");
+			return -1;
+		}
+
+		if (now - last_poll >= WIZ_NET_DISCOVERY_POLL_MS) {
+			int before = match_count;
+
+			last_poll = now;
+			NET_receiveDiscoveryResponses(udp_fd, WIZ_MAGIC, hosts, &host_count, WIZ_NET_MAX_HOSTS);
+
+			// Rebuilt from scratch rather than appended to: the dedup lives in
+			// NET_receiveDiscoveryResponses, and hosts only ever grows.
+			match_count = 0;
+			for (int i = 0; i < host_count; i++) {
+				char title[NET_MAX_GAME_NAME];
+
+				if (strcmp(hosts[i].link_mode, WIZ_NET_LINK_MODE) != 0)
+					continue;
+				if (!wiz_game_matches_broadcast(hosts[i].game_name, a->game))
+					continue;
+
+				// The field is sent raw, but a peer that escaped anyway matched
+				// above and must not put \x1f on screen.
+				snprintf(title, sizeof(title), "%s", hosts[i].game_name);
+				wiz_unesc_spaces(title);
+
+				snprintf(label_text[match_count], WIZ_NET_LABEL_MAX, "%s (%s)",
+						 title, hosts[i].host_ip);
+				labels[match_count] = label_text[match_count];
+				matches[match_count] = i;
+				match_count++;
+			}
+
+			if (match_count != before) {
+				dirty = true;
+				if (selected >= match_count)
+					selected = match_count > 0 ? match_count - 1 : 0;
+			}
+		}
+
+		GFX_startFrame();
+		PAD_poll();
+
+		if (PAD_justPressed(BTN_B) || app_quit) {
+			close(udp_fd);
+			return -2;
+		}
+
+		if (match_count > 0) {
+			if (PAD_justRepeated(BTN_UP)) {
+				selected = (selected + match_count - 1) % match_count;
+				dirty = true;
+			} else if (PAD_justRepeated(BTN_DOWN)) {
+				selected = (selected + 1) % match_count;
+				dirty = true;
+			} else if (PAD_justPressed(BTN_A)) {
+				snprintf(ip_out, ip_size, "%s", hosts[matches[selected]].host_ip);
+				close(udp_fd);
+				return 0;
+			}
+		}
+
+		PWR_update(&dirty, NULL, NULL, NULL);
+
+		if (dirty) {
+			if (match_count > 0)
+				wiz_net_render_list(labels, match_count, selected, &scroll);
+			else
+				wiz_net_render_empty("Searching for hosts...");
+			dirty = false;
+		} else {
+			GFX_sync();
+		}
+	}
+}
+
+// Read the n FILE lines and, if we want them, pull them.
+// 0 = the host may proceed, 1 = drop this host, -1 = fatal, -2 = cancelled.
+static int wiz_client_sync(const WizArgs* a, WizSession* s, int fd, WizLineReader* r, int n) {
+	char names[WIZ_NET_SYNC_MAX_FILES][WIZ_NET_NAME_MAX];
+	char line[WIZ_NET_LINE_MAX];
+	char token[WIZ_NET_TOKEN_MAX];
+
+	// --fetch-files is the whitelist; without it, or without --fetch-to, we take
+	// nothing. The FILE lines are still read to the end so both sides stay in
+	// lockstep and the host reaches its START.
+	bool fetching = (a->fetch_to != NULL && a->pattern_count > 0);
+
+	if (n < 0 || n > WIZ_NET_SYNC_MAX_FILES) {
+		wiz_send_line(fd, "SYNC-FAIL");
+		wiz_net_error("The host offered more saves\nthan expected.");
+		return -1;
+	}
+
+	for (int i = 0; i < n; i++) {
+		int rc = wiz_wait_line(r, line, sizeof(line), WIZ_NET_RECV_TIMEOUT_MS, true, "Receiving saves...");
+		if (rc == -2)
+			return -2;
+		if (rc != 0) {
+			wiz_send_line(fd, "SYNC-FAIL");
+			wiz_net_error("The host stopped responding.");
+			return 1;
+		}
+
+		if (wiz_parse_file(line, token, sizeof(token)) != 0) {
+			wiz_send_line(fd, "SYNC-FAIL");
+			wiz_net_error("Unexpected reply from the host.");
+			return -1;
+		}
+
+		wiz_unesc_spaces(token);
+
+		// A name we would not have served ourselves is a version skew or worse;
+		// either way it is not something to write into --fetch-to.
+		if (!wiz_name_is_safe(token) ||
+			(fetching && !wiz_name_matches(token, a->patterns, a->pattern_count))) {
+			wiz_send_line(fd, "SYNC-FAIL");
+			wiz_net_error("The host offered an\nunexpected file.");
+			return -1;
+		}
+
+		snprintf(names[i], WIZ_NET_NAME_MAX, "%s", token);
+	}
+
+	if (!fetching) {
+		// Offered and declined. SYNC-DONE, not SYNC-FAIL: nothing went wrong.
+		wiz_send_line(fd, "SYNC-DONE");
+		return 0;
+	}
+
+	mkdir_p(a->fetch_to);
+	wiz_net_status("Receiving saves...");
+
+	if (wiz_sync_pull(s->peer_ip, a->fetch_to, names, n) != 0) {
+		wiz_send_line(fd, "SYNC-FAIL");
+		wiz_net_error("Could not copy the host's saves.");
+		return -1;
+	}
+
+	wiz_send_line(fd, "SYNC-DONE");
+	return 0;
+}
+
+// One connected control channel, start to finish. fd stays owned by the caller.
+// 0 = rendezvous complete, 1 = drop this host (message drawn; the WiFi client
+// goes back to its list), -1 = fatal (message drawn), -2 = cancelled.
+static int wiz_client_session(const WizArgs* a, WizSession* s, int fd, const char* host_ip) {
+	WizLineReader reader;
+	char line[WIZ_NET_LINE_MAX];
+	char escaped[WIZ_NET_TOKEN_MAX];
+	char game[WIZ_NET_TOKEN_MAX];
+	char reason[32];
+	char role[16];
+	int version = 0;
+	int n = 0;
+
+	wiz_reader_init(&reader, fd);
+	wiz_esc_spaces(a->game, escaped, sizeof(escaped));
+
+	if (wiz_send_line(fd, "HELLO %d %s client", WIZ_PROTO_VERSION, escaped) != 0) {
+		wiz_net_error("Connection failed.\n\nPlease try again.");
+		return 1;
+	}
+
+	int rc = wiz_wait_line(&reader, line, sizeof(line), WIZ_NET_RECV_TIMEOUT_MS, true,
+						   "Waiting for the host...");
+	if (rc == -2)
+		return -2;
+	if (rc != 0) {
+		wiz_net_error("The host did not answer.\n\nPlease try again.");
+		return 1;
+	}
+
+	if (wiz_parse_reject(line, reason, sizeof(reason)) == 0) {
+		wiz_net_error(wiz_reject_message(reason));
+		return 1;
+	}
+
+	if (wiz_parse_hello(line, &version, game, sizeof(game), role, sizeof(role)) != 0) {
+		wiz_net_error("That device is not waiting\nfor a netplay player.");
+		return 1;
+	}
+
+	wiz_unesc_spaces(game);
+
+	const char* mismatch = wiz_hello_mismatch(version, game, role, a->game, "host");
+	if (mismatch) {
+		wiz_net_error(wiz_reject_message(mismatch));
+		return 1;
+	}
+
+	snprintf(s->peer_ip, sizeof(s->peer_ip), "%s", host_ip);
+
+	// Next line is SYNC-READY when the host serves saves, START when it does not.
+	rc = wiz_wait_line(&reader, line, sizeof(line), WIZ_NET_RECV_TIMEOUT_MS, true,
+					   "Waiting for the host...");
+	if (rc == -2) {
+		s->peer_ip[0] = '\0';
+		return -2;
+	}
+	if (rc != 0) {
+		s->peer_ip[0] = '\0';
+		wiz_net_error("The host did not answer.\n\nPlease try again.");
+		return 1;
+	}
+
+	if (wiz_parse_reject(line, reason, sizeof(reason)) == 0) {
+		s->peer_ip[0] = '\0';
+		wiz_net_error(wiz_reject_message(reason));
+		return 1;
+	}
+
+	if (wiz_parse_sync_ready(line, &n) == 0) {
+		int src = wiz_client_sync(a, s, fd, &reader, n);
+		if (src != 0) {
+			s->peer_ip[0] = '\0';
+			return src;
+		}
+
+		rc = wiz_wait_line(&reader, line, sizeof(line), WIZ_NET_RECV_TIMEOUT_MS, true, "Starting...");
+		if (rc == -2) {
+			s->peer_ip[0] = '\0';
+			return -2;
+		}
+		if (rc != 0) {
+			s->peer_ip[0] = '\0';
+			wiz_net_error("The host did not answer.\n\nPlease try again.");
+			return 1;
+		}
+	}
+
+	if (strcmp(line, "START") != 0) {
+		s->peer_ip[0] = '\0';
+		wiz_net_error("Unexpected reply from the host.");
+		return 1;
+	}
+
+	if (wiz_send_line(fd, "START") != 0) {
+		s->peer_ip[0] = '\0';
+		wiz_net_error("Connection lost.\n\nPlease try again.");
+		return 1;
+	}
+
+	return 0;
+}
+
+// Hotspot arm: one known address, no list to go back to.
+static int wiz_client_hotspot(const WizArgs* a, WizSession* s) {
+	// The association is seconds old — ARP and the default route may not be in
+	// place yet, and the first SYN into that gap reads to the user as a refused
+	// connection. One ping settles it. It blocks for up to 2 s, so put the
+	// screen up first rather than leaving wizard_wifi.c's last frame on show.
+	wiz_net_status("Connecting to host...");
+	system("ping -c 1 -W 2 " WIFI_DIRECT_HOTSPOT_IP " >/dev/null 2>&1");
+
+	for (int attempt = 1; attempt <= WIZ_NET_CONNECT_ATTEMPTS; attempt++) {
+		char status[64];
+		int fd = -1;
+
+		if (attempt == 1)
+			snprintf(status, sizeof(status), "Connecting to host...");
+		else
+			snprintf(status, sizeof(status), "Retrying connection... (%d/%d)",
+					 attempt, WIZ_NET_CONNECT_ATTEMPTS);
+
+		int rc = wiz_connect(WIFI_DIRECT_HOTSPOT_IP, WIZ_TCP_PORT,
+							 WIZ_NET_CONNECT_TIMEOUT_MS, status, &fd);
+		if (rc == -2)
+			return -2;
+
+		if (rc == 0) {
+			int src = wiz_client_session(a, s, fd, WIFI_DIRECT_HOTSPOT_IP);
+			close(fd);
+
+			if (src == 0)
+				return 0;
+			if (src == -2)
+				return -2;
+			// Nothing to fall back to here: the message is already up.
+			return -1;
+		}
+
+		if (attempt < WIZ_NET_CONNECT_ATTEMPTS && wiz_wait_ms(WIZ_NET_RETRY_DELAY_MS, true, status) == -2)
+			return -2;
+	}
+
+	wiz_net_error("Could not reach the host.\n\nMake sure the host is\nwaiting for a player.");
+	return -1;
+}
+
+int wiz_client_rendezvous(const WizArgs* a, WizSession* s) {
+	if (strcmp(s->mode, "hotspot") == 0)
+		return wiz_client_hotspot(a, s);
+
+	// WiFi: anything short of a fatal error goes back to the list, because the
+	// host that refused us may not be the only one broadcasting.
+	while (1) {
+		char host_ip[16] = {0};
+		char status[64];
+		int fd = -1;
+
+		int rc = wiz_client_pick_host(a, host_ip, sizeof(host_ip));
+		if (rc != 0)
+			return rc;
+
+		snprintf(status, sizeof(status), "Connecting to %s...", host_ip);
+
+		rc = wiz_connect(host_ip, WIZ_TCP_PORT, WIZ_NET_CONNECT_TIMEOUT_MS, status, &fd);
+		if (rc == -2)
+			continue; // B during the connect: back to the list, not out
+		if (rc != 0) {
+			wiz_net_error("Connection failed.\n\nThe host may have stopped\nwaiting.");
+			continue;
+		}
+
+		int src = wiz_client_session(a, s, fd, host_ip);
+		close(fd);
+
+		if (src == 0)
+			return 0;
+		if (src == -1 || src == -2)
+			return src;
+		// src == 1: refused or dropped, message drawn — pick again.
+	}
+}

--- a/workspace/all/netplay-wizard/wizard_sync.c
+++ b/workspace/all/netplay-wizard/wizard_sync.c
@@ -1,0 +1,968 @@
+/*
+ * Wizard save sync — rsyncd on the host, one-shot pull on the client.
+ *
+ * The host publishes exactly one module, [sync] over serve_dir, on
+ * WIZ_RSYNC_PORT, and only for the length of one handshake: wizard_net.c starts
+ * it after the HELLO exchange and stops it the moment the client reports back
+ * (wizard_net.c:733/747/755). Two lines of its config are the whole security
+ * posture, and they are the two lines NOT copied from Device Sync's rsyncd.conf
+ * (sync.c:384-409, which offers three writable modules to anyone who asks):
+ *
+ *     read only = true     the client pulls; nothing on the wire may write here
+ *     hosts allow = <ip>   only the peer that just completed the handshake
+ *
+ * EXEC SAFETY. The names that reach wiz_sync_pull() are remote input — they
+ * arrive as FILE lines on the control channel. wizard_net.c:369 whitelists them
+ * to [A-Za-z0-9._-]+, but a whitelist upstream is a second line of defence and
+ * never a licence to interpolate, so the pull runs posix_spawn(RSYNC_BIN, argv)
+ * with NO SHELL ANYWHERE. There is no command string to quote and therefore
+ * nothing for a quote, space, semicolon or backtick in a name to break out of;
+ * the whitelist and the spawn each stand on their own. sync.c:546 uses popen()
+ * (which is a shell) for the same job, and this file deliberately parts company
+ * with it there — that is the one pattern from sync.c not copied.
+ *
+ * The two system() calls that remain — starting the daemon and killall rsync —
+ * carry no data at all: every byte of both command strings is a compile-time
+ * constant. What does vary (serve_dir, the peer's address) goes into the config
+ * FILE, never onto a command line, and is checked on the way in for the one
+ * character that would matter there.
+ *
+ * ALL OR NOTHING, and it is the staging directory that makes that literal. Every
+ * file is pulled into fetch_to/.netplay-staging and renamed into fetch_to only
+ * once the WHOLE set has arrived; a failure removes the staging directory and
+ * leaves fetch_to exactly as it was. Deleting the fetched names out of fetch_to
+ * instead — the obvious approach — cannot distinguish a file rsync wrote from
+ * one it SKIPPED as already up to date (`-t` without `--checksum` compares size
+ * and mtime), so a set that failed half way would delete intact local saves the
+ * transfer never touched. A half-synced VMU set must never reach the game, and
+ * neither must a half-deleted one.
+ */
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE // O_DIRECTORY, unlinkat, posix_spawn
+#endif
+
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <spawn.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/select.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "api.h"
+#include "defines.h"
+#include "ui_buttonhintbar.h"
+#include "ui_list.h"
+#include "ui_message.h"
+#include "wizard.h"
+
+// posix_spawn's environment. POSIX leaves this one to the caller to declare.
+extern char** environ;
+
+// rsync binary path (shared across platforms). Same definition as sync.c:41,
+// duplicated rather than shared because nothing in sync.c is linkable here.
+#define RSYNC_BIN SHARED_BIN_PATH "/rsync"
+
+// How long the daemon gets to write its pidfile before we call it dead
+// (sync.c:423).
+#define WIZ_SYNC_DAEMON_SETTLE_US 500000
+
+// Hard ceilings on the client's pull, in the order they bind: one file may not
+// hold the UI longer than FILE, and the whole set may not exceed TOTAL.
+//
+// CROSS-FILE INVARIANT. The client must reach its SYNC-FAIL before the host
+// stops listening, and FOUR constants in this file govern that, not one. Every
+// step between the deadline firing and wizard_net.c:1118 sending the line:
+//
+//     WIZ_SYNC_TOTAL_TIMEOUT_MS    23000   the budget itself
+//   + WIZ_SYNC_POLL_US as ms         100   deadline is read once per poll
+//   + WIZ_SYNC_REAP_GRACE_MS        2000   worst case waiting for the child
+//   + WIZ_SYNC_ERROR_TIMEOUT_MS     2000   drawn BEFORE wiz_sync_pull returns
+//   ---------------------------------------
+//                                  27100 < 30000 (WIZ_NET_PULL_TIMEOUT_MS)
+//
+// 2.9 s of margin, and it is not all spare: the host starts its 30 s clock when
+// it sends SYNC-READY, while the client starts this budget only after reading
+// the n FILE lines that follow, so that difference is charged here too.
+//
+// All four are load-bearing. Raising the error hold to wizard_net.c's 5 s idiom
+// inverts the ordering just as surely as raising TOTAL would, and the reap grace
+// joined the sum the moment wiz_reap() replaced a bare waitpid(). The 30 s on
+// the other side is wizard_net.c's, not this file's to move; the margin is
+// restored from here. The native test asserts this sum across both files.
+#define WIZ_SYNC_FILE_TIMEOUT_MS 15000
+#define WIZ_SYNC_TOTAL_TIMEOUT_MS 23000
+// rsync's own timeouts: the polite version of the two above, so a peer that
+// vanished fails with rsync's own error before anything gets SIGKILLed. Both are
+// supported by the bundled binary (skeleton/SYSTEM/shared/bin/rsync).
+#define WIZ_SYNC_IO_TIMEOUT_S 8
+#define WIZ_SYNC_CONNECT_TIMEOUT_S 4
+
+// Progress poll cadence, and so also the longest the read loop can go without
+// noticing its own deadline.
+#define WIZ_SYNC_POLL_US 100000
+// Deliberately shorter than wizard_net.c's 5 s: it is inside the SYNC-FAIL
+// budget above, and see wiz_sync_error().
+#define WIZ_SYNC_ERROR_TIMEOUT_MS 2000
+
+// How long a child that closed its output gets to exit before the whole process
+// group is killed, and how often that is checked. Nothing here ever waits on a
+// child without a bound.
+#define WIZ_SYNC_REAP_GRACE_MS 2000
+#define WIZ_SYNC_REAP_POLL_US 20000
+
+// Must equal the literal in wizard.h's wiz_sync_pull() signature: the parameter
+// is char names[][64] and this is what indexes it here.
+#define WIZ_SYNC_NAME_MAX 64
+// Longest run of rsync output held at once. --info=progress2 emits one short
+// line per redraw, so this is slack, not a budget.
+#define WIZ_SYNC_LINE_MAX 512
+// Where a pull lands before any of it is allowed into fetch_to. Inside fetch_to
+// so the commit is a same-filesystem rename; leading dot so a directory listing
+// (and NextUI's own file browsers, which hide dotfiles) does not show it.
+#define WIZ_SYNC_STAGE_DIR ".netplay-staging"
+// Longest path this file builds: fetch_to + '/' + staging + '/' + a 63-char name.
+#define WIZ_SYNC_PATH_MAX 512
+
+//////////////////////////////////
+// Screens
+//////////////////////////////////
+
+// Terminal message, the twin of wizard_net.c's wiz_net_error() and
+// wizard_wifi.c's wiz_error(): same frame, same dismissal, file-local to this
+// stage of the wizard. One deliberate difference — the hold is shorter, because
+// every caller of the functions below draws its own error straight after a -1
+// (wizard_net.c:736 and :1119), and two five-second screens back to back read as
+// a hang. This one names what broke; the caller's names what it means for the
+// game.
+static void wiz_sync_error(const char* message) {
+	GFX_clear(wiz_screen);
+	UI_renderCenteredMessage(wiz_screen, message);
+	UI_renderButtonHintBar(wiz_screen, (char*[]){"A", "OKAY", NULL});
+	GFX_flip(wiz_screen);
+
+	uint32_t start = SDL_GetTicks();
+	while (SDL_GetTicks() - start < WIZ_SYNC_ERROR_TIMEOUT_MS) {
+		GFX_startFrame();
+		PAD_poll();
+		if (PAD_justPressed(BTN_A) || PAD_justPressed(BTN_B))
+			break;
+		GFX_sync();
+	}
+}
+
+// Caption counts files, bar counts bytes of the file in flight. Drawn straight
+// rather than through the frame loop: the read loop it belongs to is blocked on
+// rsync between calls, so there is no frame to be in step with — the same window
+// the host spends inside wiz_wait_line() with B disabled.
+static void wiz_sync_render_progress(int index, int count, int percent) {
+	char message[64];
+	int bar_w = wiz_screen->w - SCALE1(PADDING * 8);
+	int bar_h = SCALE1(12);
+	int bar_x = SCALE1(PADDING * 4);
+	int bar_y = wiz_screen->h / 2 + SCALE1(10);
+	int fill_w;
+
+	if (percent < 0)
+		percent = 0;
+	if (percent > 100)
+		percent = 100;
+	fill_w = (bar_w * percent) / 100;
+
+	snprintf(message, sizeof(message), "Copying saves... (%d/%d)", index + 1, count);
+
+	GFX_clear(wiz_screen);
+	// GFX_blitText centres inside dst_rect, so a full-width rect is a centred
+	// line (wizard_net.c:146 does the same).
+	GFX_blitText(font.medium, message, 0, COLOR_WHITE, wiz_screen,
+				 &(SDL_Rect){0, bar_y - SCALE1(FONT_MEDIUM + PADDING), wiz_screen->w,
+							 SCALE1(FONT_MEDIUM)});
+
+	UI_renderRoundedRectBg(wiz_screen, bar_x, bar_y, bar_w, bar_h, RGB_DARK_GRAY);
+	// UI_fillRoundedRect clamps its radius to w/2, so a fill narrower than the
+	// corner radius still draws; no minimum width needed.
+	if (fill_w > 0)
+		UI_renderRoundedRectBg(wiz_screen, bar_x, bar_y, fill_w, bar_h, THEME_COLOR1);
+
+	GFX_flip(wiz_screen);
+}
+
+//////////////////////////////////
+// Pure helpers
+//////////////////////////////////
+//
+// No sockets, no SDL, no daemon: text in, text out. Same split as wizard_net.c's
+// wire-protocol section and for the same reason — this is the half that can be
+// exercised on a development host, and it is the half that handles remote input.
+
+// A value on its way into rsyncd.conf. That file is line-oriented (one directive
+// per line, value to end of line), so a \n or \r inside a value would end the
+// directive early and start one the caller never wrote — "hosts allow = x\nhosts
+// allow = *" being the case that matters. Both values written here are trusted by
+// construction; this is what makes that assumption checkable rather than assumed.
+static bool wiz_conf_value_is_safe(const char* value) {
+	if (!value || !value[0])
+		return false;
+
+	for (const char* c = value; *c; c++)
+		if (*c == '\n' || *c == '\r')
+			return false;
+
+	return true;
+}
+
+// A dotted quad, by shape. `hosts allow` also accepts names, ranges and
+// patterns, so anything that is not digits and dots would WIDEN that ACL rather
+// than narrow it ("*" being the extreme). wizard_net.c fills peer_ip from
+// inet_ntop() and the client dials an address read the same way, so [0-9.] is
+// the entire alphabet either side can produce. Shape only — this is not an
+// address parser, and rsync validates the value itself.
+static bool wiz_ip_is_plain(const char* ip) {
+	int digits = 0;
+
+	if (!ip || !ip[0] || strlen(ip) >= 16)
+		return false;
+
+	for (const char* c = ip; *c; c++) {
+		if (*c >= '0' && *c <= '9') {
+			digits++;
+			continue;
+		}
+		if (*c == '.')
+			continue;
+		return false;
+	}
+
+	return digits > 0;
+}
+
+// The whitelist wizard_net.c:369 applies on the wire, re-applied at this module's
+// own boundary. Not redundancy for its own sake:
+//   - these names are remote input and this file hands them to an exec and to
+//     unlinkat(); a '/' or a ".." would reach outside fetch_to either way,
+//   - wiz_name_is_safe() is static to wizard_net.c and cannot be seen from here,
+//     and
+//   - a caller added later (a bench harness, Task 7's launch glue) must not be
+//     able to skip the check by not being wizard_net.c.
+// Deliberately identical to that one, down to the explicit ranges instead of
+// isalnum() (locale-dependent); if either moves, both move.
+static bool wiz_sync_name_is_safe(const char* name) {
+	if (!name || !name[0])
+		return false;
+	if (strlen(name) >= WIZ_SYNC_NAME_MAX)
+		return false;
+	if (name[0] == '-') // rsync would read it as an option
+		return false;
+	if (strcmp(name, ".") == 0 || strcmp(name, "..") == 0)
+		return false;
+
+	for (const char* c = name; *c; c++) {
+		if (*c >= 'A' && *c <= 'Z')
+			continue;
+		if (*c >= 'a' && *c <= 'z')
+			continue;
+		if (*c >= '0' && *c <= '9')
+			continue;
+		if (*c == '.' || *c == '_' || *c == '-')
+			continue;
+		return false;
+	}
+
+	return true;
+}
+
+// The host's rsyncd.conf, written to an already-open stream so the exact file
+// can be checked without starting a daemon. Diverges from sync.c's
+// write_rsync_config() in four ways, all of them the security posture: one
+// module instead of three, read only = true instead of no, a hosts allow naming
+// the single peer instead of no ACL at all, and list = false.
+//
+// list = false is not decoration. `hosts allow` is enforced when a MODULE is
+// opened, not when the daemon is asked to enumerate them, so without it a device
+// that is not the paired peer still gets "sync" back from
+// `rsync rsync://<host>:18731/` (verified against the shipped rsync 3.2.0dev:
+// the pull is refused with "@ERROR: access denied" but the listing is served).
+// With it the listing comes back empty and an explicit pull by name still works,
+// which is the only access this protocol needs.
+//
+// transfer logging is left off for the same family of reasons: the log would
+// otherwise name every file the peer read, and it lives in /tmp.
+// 0 = the whole file was written, -1 = the stream errored.
+static int wiz_write_serve_conf(FILE* fp, const char* serve_dir, const char* client_ip) {
+	fprintf(fp, "pid file = %s\n", WIZ_RSYNC_PID);
+	fprintf(fp, "port = %d\n", WIZ_RSYNC_PORT);
+	fprintf(fp, "use chroot = no\n");
+	fprintf(fp, "uid = 0\n");
+	fprintf(fp, "gid = 0\n");
+	fprintf(fp, "log file = %s\n", WIZ_RSYNC_LOG);
+	fprintf(fp, "hosts allow = %s\n\n", client_ip);
+	fprintf(fp, "[sync]\n");
+	fprintf(fp, "  path = %s\n", serve_dir);
+	fprintf(fp, "  read only = true\n");
+	fprintf(fp, "  list = false\n");
+
+	return ferror(fp) ? -1 : 0;
+}
+
+// Index of the first name that repeats an earlier one, or -1 when the set is
+// what it claims to be: a set. O(n²) over at most WIZ_NET_SYNC_MAX_FILES = 32
+// names, i.e. free.
+static int wiz_find_duplicate(char names[][WIZ_SYNC_NAME_MAX], int count) {
+	for (int i = 1; i < count; i++)
+		for (int j = 0; j < i; j++)
+			if (strcmp(names[i], names[j]) == 0)
+				return i;
+
+	return -1;
+}
+
+// rsync://<host>:<port>/sync/<name>. One file, one URL — split out so the exact
+// string handed to the exec can be checked without a daemon.
+static void wiz_build_pull_url(char* out, size_t out_size, const char* host_ip, const char* name) {
+	snprintf(out, out_size, "rsync://%s:%d/sync/%s", host_ip, WIZ_RSYNC_PORT, name);
+}
+
+// The percentage an --info=progress2 line carries, or -1 for a line that carries
+// none (rsync's banners, blank lines). The line reads
+//
+//     131,072 100%   12.50MB/s    0:00:00 (xfr#1, to-chk=0/1)
+//
+// so the first '%' with digits in front of it is the transfer percentage; the
+// rate that follows carries no '%' of its own. Bytes, not files, because this bar
+// is per-file: sync.c:450 counts files out of "to-chk=X/Y", which for a
+// single-file pull only ever reads 0% then 100%.
+static int wiz_progress_percent(const char* line) {
+	for (const char* c = line; *c; c++) {
+		const char* start = c;
+		int percent;
+
+		if (*c != '%')
+			continue;
+
+		while (start > line && start[-1] >= '0' && start[-1] <= '9')
+			start--;
+		if (start == c)
+			continue; // a '%' with no number in front of it
+
+		percent = atoi(start);
+		if (percent < 0)
+			percent = 0;
+		if (percent > 100)
+			percent = 100;
+		return percent;
+	}
+
+	return -1;
+}
+
+// Consume every complete line in buf, returning the newest percentage they
+// carried (or `current` when none did) and moving the unterminated tail to the
+// front. Lines end with \r OR \n: --info=progress2 redraws in place with \r and
+// only ends with \n, which is why sync.c:480 reads the same way. This one works
+// off a buffer rather than fgetc() because the caller has to select() on the same
+// descriptor for its deadline, and stdio's buffer is invisible to select().
+//
+// A buffer that fills up with no terminator in it at all is not progress output,
+// so it is dropped rather than grown — which is also what guarantees the caller
+// always has room to read into.
+static int wiz_take_percent(char* buf, size_t size, size_t* len, int current) {
+	size_t start = 0;
+	int percent = current;
+
+	for (size_t i = 0; i < *len; i++) {
+		if (buf[i] != '\r' && buf[i] != '\n')
+			continue;
+
+		buf[i] = '\0';
+		if (i > start) {
+			int found = wiz_progress_percent(buf + start);
+			if (found >= 0)
+				percent = found;
+		}
+		start = i + 1;
+	}
+
+	if (start > 0) {
+		memmove(buf, buf + start, *len - start);
+		*len -= start;
+	} else if (*len == size) {
+		*len = 0;
+	}
+
+	return percent;
+}
+
+//////////////////////////////////
+// Staging directory
+//////////////////////////////////
+//
+// Nothing the host sends is written into fetch_to. Every file lands in
+// fetch_to/.netplay-staging first and is renamed in only once the WHOLE set has
+// arrived, which is what makes the all-or-nothing rule true rather than
+// approximately true.
+//
+// The rule this replaces — pull straight into fetch_to and unlink the names
+// again on failure — cannot tell "rsync wrote this" from "this was already
+// here". `-t` without `--checksum` SKIPS a file whose size and mtime already
+// match, so two devices that synced yesterday and fail today would have had an
+// intact, untouched local save deleted by the failure path. That is silent save
+// loss on a device whose entire purpose is saves.
+//
+// No SDL and no network below: filesystem only, so the whole flow is exercisable
+// on a development host.
+
+// fetch_to/.netplay-staging.
+static void wiz_stage_path(char* out, size_t out_size, const char* fetch_to) {
+	snprintf(out, out_size, "%s/%s", fetch_to, WIZ_SYNC_STAGE_DIR);
+}
+
+// The staging directory and everything in it, gone. Runs as the failure path,
+// after a successful commit (by then it is empty), and again before a pull
+// starts — a directory that already exists belongs to a run that was killed, so
+// it is neither ours to commit nor the user's to keep.
+//
+// ONE LEVEL DEEP, deliberately. rsync is invoked without -r and without -d, so
+// it never creates a directory in the destination; the only things in here are
+// this file's own single-file pulls. The AT_REMOVEDIR fallback below therefore
+// only ever has to clear an EMPTY directory left by something else. A non-empty
+// one would survive, rmdir() would fail, and the next wiz_stage_prepare() would
+// then fail on mkdir() and take wiz_sync_pull() out with fetch_to untouched —
+// i.e. this fails closed, which is why it does not need to recurse.
+static void wiz_stage_purge(const char* fetch_to) {
+	char path[WIZ_SYNC_PATH_MAX];
+	DIR* dir;
+
+	wiz_stage_path(path, sizeof(path), fetch_to);
+
+	dir = opendir(path);
+	if (dir) {
+		int dir_fd = dirfd(dir);
+		struct dirent* entry;
+
+		while ((entry = readdir(dir)) != NULL) {
+			if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
+				continue;
+			if (dir_fd < 0)
+				continue;
+			// Only ever our own pulls in here, but a directory left by anything
+			// else must not stop the purge from finishing.
+			if (unlinkat(dir_fd, entry->d_name, 0) != 0)
+				unlinkat(dir_fd, entry->d_name, AT_REMOVEDIR);
+		}
+
+		closedir(dir);
+	}
+
+	rmdir(path);
+}
+
+// An empty staging directory, ready to receive. 0 = it exists and is empty.
+static int wiz_stage_prepare(const char* fetch_to) {
+	char path[WIZ_SYNC_PATH_MAX];
+
+	wiz_stage_purge(fetch_to);
+	wiz_stage_path(path, sizeof(path), fetch_to);
+
+	return mkdir(path, 0755) == 0 ? 0 : -1;
+}
+
+// Move the finished set into fetch_to, one rename() per name. Same filesystem by
+// construction (the staging directory is inside fetch_to), so each rename is
+// atomic and replaces a local save only at the instant the whole set is known
+// good. 0 = every name moved.
+//
+// A failure part-way leaves the earlier renames in place: POSIX cannot move a
+// set atomically. That window is the microseconds between two renames in a
+// directory this process owns, against the multi-second transfer window the
+// staging directory removes — and every rename that did land is a complete,
+// correct file, so a retry simply redoes them. Best effort rather than
+// stop-at-first-failure for the same reason: the closer to the full set, the
+// better off both sides are.
+static int wiz_stage_commit(const char* fetch_to, char names[][WIZ_SYNC_NAME_MAX], int count) {
+	char path[WIZ_SYNC_PATH_MAX];
+	int stage_fd;
+	int dest_fd;
+	int result = 0;
+
+	wiz_stage_path(path, sizeof(path), fetch_to);
+
+	stage_fd = open(path, O_RDONLY | O_DIRECTORY);
+	if (stage_fd < 0)
+		return -1;
+
+	dest_fd = open(fetch_to, O_RDONLY | O_DIRECTORY);
+	if (dest_fd < 0) {
+		close(stage_fd);
+		return -1;
+	}
+
+	for (int i = 0; i < count; i++)
+		if (renameat(stage_fd, names[i], dest_fd, names[i]) != 0)
+			result = -1;
+
+	close(dest_fd);
+	close(stage_fd);
+	return result;
+}
+
+//////////////////////////////////
+// Daemon (host side)
+//////////////////////////////////
+
+// Idempotent, and called on every exit path including wiz_sync_serve_start()'s
+// own failures. Clone of sync.c:430-442 plus the log.
+void wiz_sync_serve_stop(void) {
+	FILE* fp = fopen(WIZ_RSYNC_PID, "r");
+
+	if (fp) {
+		int pid = 0;
+		if (fscanf(fp, "%d", &pid) == 1 && pid > 0)
+			kill(pid, SIGTERM);
+		fclose(fp);
+		unlink(WIZ_RSYNC_PID);
+	}
+
+	// A daemon that died before writing its pidfile leaves no other handle, so
+	// this is not belt-and-braces (sync.c:440 does the same for the same
+	// reason). Safe here: the only other rsync user on the device is sync.elf,
+	// a launcher app, which cannot be running while launch.sh has a game
+	// mid-launch — and the wizard's own pull is a client that has already
+	// finished by the time anything calls this.
+	system("killall rsync 2>/dev/null");
+
+	unlink(WIZ_RSYNC_CONF);
+	// Not in sync.c: the log names the peer and every file it read, and /tmp
+	// outlives this process. The session ends, the record goes with it.
+	unlink(WIZ_RSYNC_LOG);
+}
+
+int wiz_sync_serve_start(const char* serve_dir, const char* client_ip) {
+	char cmd[512];
+	FILE* fp;
+	int wrote;
+
+	// serve_dir is launch.sh argv (DC.pak's own config, trusted local input) and
+	// client_ip is inet_ntop() output from the accepted socket (digits and dots
+	// by construction). Both assumptions are checked rather than relied on,
+	// because the file they land in is parsed as configuration.
+	if (!wiz_conf_value_is_safe(serve_dir) || !wiz_ip_is_plain(client_ip)) {
+		wiz_sync_error("Could not share saves.");
+		return -1;
+	}
+
+	if (access(RSYNC_BIN, X_OK) != 0) {
+		// Nothing created yet, so nothing to unwind.
+		wiz_sync_error("Save sharing is not\navailable on this device.");
+		return -1;
+	}
+
+	// Start from a known state. Two different leftovers are possible after a
+	// launch that was killed mid-session: a pidfile with nothing behind it,
+	// which would make the check below pass without a daemon (rsync writes that
+	// file only after it binds), and a daemon still holding port 18731, which
+	// would make the new one fail to bind. Both are the teardown that never ran,
+	// so run it.
+	wiz_sync_serve_stop();
+
+	fp = fopen(WIZ_RSYNC_CONF, "w");
+	if (!fp) {
+		wiz_sync_error("Could not share saves.");
+		return -1;
+	}
+
+	// From here on the process owns state on disk, and every failure path below
+	// hands it back before returning.
+	wrote = wiz_write_serve_conf(fp, serve_dir, client_ip);
+	if (fclose(fp) != 0)
+		wrote = -1;
+
+	if (wrote != 0) {
+		wiz_sync_serve_stop();
+		wiz_sync_error("Could not share saves.");
+		return -1;
+	}
+
+	// No data in this command line: both halves are compile-time constants, so
+	// system() here carries none of the risk the pull's argv would.
+	snprintf(cmd, sizeof(cmd), "%s --daemon --config=%s", RSYNC_BIN, WIZ_RSYNC_CONF);
+	if (system(cmd) != 0) {
+		wiz_sync_serve_stop();
+		wiz_sync_error("Could not start the\nsave server.");
+		return -1;
+	}
+
+	usleep(WIZ_SYNC_DAEMON_SETTLE_US);
+	if (access(WIZ_RSYNC_PID, F_OK) != 0) {
+		// Forked cleanly and then refused to bind (port already held, serve_dir
+		// unreadable). The daemon is the one thing killall can still catch.
+		wiz_sync_serve_stop();
+		wiz_sync_error("Could not start the\nsave server.");
+		return -1;
+	}
+
+	return 0;
+}
+
+//////////////////////////////////
+// Pull (client side)
+//////////////////////////////////
+
+// Start rsync with no shell between us and it: argv reaches the kernel as it
+// stands, so nothing in it is parsed for metacharacters (see the file header).
+// stdout and stderr both land on the returned descriptor — the shell's "2>&1"
+// without the shell. 0 = *out_fd and *out_pid are the caller's to close and reap.
+//
+// The child is put in its own PROCESS GROUP, which is load-bearing rather than
+// tidy. rsync in receiving mode forks: the process spawned here becomes the
+// generator and a child of it becomes the receiver — and the receiver is the one
+// that opens and writes the destination file. On a clean exit the generator
+// signals the receiver itself, but a SIGKILL aimed at the generator alone skips
+// that, and the receiver is reparented to init and keeps transferring at full
+// rate (measured: still growing the destination ten seconds after the kill,
+// closing our end of the pipe does not stop it — it talks to the generator over
+// its own pipe, not stdout). That orphan would outlive the wizard into the game
+// session, holding WiFi, CPU, the wizard's inherited sockets, and could re-create
+// a file after the staging directory was discarded. pgid = the child's own pid
+// means kill(-pid) reaches the whole family and nothing survives.
+//
+// The trade this makes, stated because it is a real one: rsync is no longer in
+// the wizard's process group, so a signal sent to THAT group (a launcher killing
+// the whole job) no longer reaches it. Contained by where it can write — only
+// inside fetch_to/.netplay-staging, which is never a save the game reads and
+// which the next wiz_stage_prepare() purges — and bounded by rsync's own
+// --timeout. Every path this file takes kills the group explicitly, so the
+// window is a wizard killed from outside, not one that returned.
+static int wiz_spawn_rsync(char* const argv[], int* out_fd, pid_t* out_pid) {
+	posix_spawn_file_actions_t actions;
+	posix_spawnattr_t attr;
+	int fds[2];
+	pid_t pid = -1;
+	int rc;
+
+	*out_fd = -1;
+	*out_pid = -1;
+
+	if (pipe(fds) != 0)
+		return -1;
+
+	if (posix_spawn_file_actions_init(&actions) != 0) {
+		close(fds[0]);
+		close(fds[1]);
+		return -1;
+	}
+
+	if (posix_spawnattr_init(&attr) != 0) {
+		posix_spawn_file_actions_destroy(&actions);
+		close(fds[0]);
+		close(fds[1]);
+		return -1;
+	}
+
+	posix_spawnattr_setflags(&attr, POSIX_SPAWN_SETPGROUP);
+	posix_spawnattr_setpgroup(&attr, 0); // 0 = "your own pid", i.e. a new group
+
+	posix_spawn_file_actions_adddup2(&actions, fds[1], STDOUT_FILENO);
+	posix_spawn_file_actions_adddup2(&actions, fds[1], STDERR_FILENO);
+	// Actions run in order, so these close the originals after the dup2s above
+	// have copied them. Closing our read end in the child is what makes read()
+	// see EOF when rsync exits; the guard covers the (unreachable here, but free)
+	// case of a pipe landing on a standard descriptor, where closing it would
+	// close the output we just redirected.
+	if (fds[0] > STDERR_FILENO)
+		posix_spawn_file_actions_addclose(&actions, fds[0]);
+	if (fds[1] > STDERR_FILENO)
+		posix_spawn_file_actions_addclose(&actions, fds[1]);
+
+	rc = posix_spawn(&pid, RSYNC_BIN, &actions, &attr, argv, environ);
+	posix_spawnattr_destroy(&attr);
+	posix_spawn_file_actions_destroy(&actions);
+	close(fds[1]);
+
+	if (rc != 0) {
+		close(fds[0]);
+		return -1;
+	}
+
+	*out_fd = fds[0];
+	*out_pid = pid;
+	return 0;
+}
+
+// Reap the spawned generator without ever waiting on it indefinitely. A child
+// that has closed its output is exiting and needs no help, so it gets grace_ms
+// of WNOHANG polling; anything still there after that has the whole process
+// group killed under it. The final wait is bounded by SIGKILL being uncatchable.
+//
+// Only the generator is reaped, and that is correct: once the group is dead the
+// receiver belongs to init. 0 = *status is valid.
+static int wiz_reap(pid_t pid, int* status, uint32_t grace_ms) {
+	uint32_t start = SDL_GetTicks();
+
+	while (SDL_GetTicks() - start < grace_ms) {
+		pid_t got = waitpid(pid, status, WNOHANG);
+
+		if (got == pid)
+			return 0;
+		if (got < 0) {
+			if (errno == EINTR)
+				continue;
+			return -1; // ECHILD: nothing of ours left to wait for
+		}
+
+		usleep(WIZ_SYNC_REAP_POLL_US);
+	}
+
+	kill(-pid, SIGKILL);
+
+	while (waitpid(pid, status, 0) < 0) {
+		if (errno == EINTR)
+			continue;
+		return -1;
+	}
+
+	return 0;
+}
+
+// One file, start to finish, into the STAGING directory — never into fetch_to.
+// index/count drive the caption only; deadline is an absolute SDL_GetTicks()
+// value. No message is drawn here — the caller draws one for the pull as a
+// whole. 0 = the file is staged, -1 = anything else, with *expired telling the
+// caller which kind of failure to name.
+static int wiz_pull_one(const char* host_ip, const char* stage_dir, const char* name,
+						int index, int count, uint32_t deadline, bool* expired) {
+	char url[128 + WIZ_SYNC_NAME_MAX];
+	char dest[WIZ_SYNC_PATH_MAX];
+	char io_timeout[32];
+	char con_timeout[32];
+	char buf[WIZ_SYNC_LINE_MAX];
+	size_t len = 0;
+	int percent = 0;
+	int shown = -1;
+	int fd = -1;
+	pid_t pid = -1;
+	int status = 0;
+	bool eof = false;
+	bool timed_out = false;
+
+	// Set before the first return so no caller can read a previous file's value.
+	*expired = false;
+
+	wiz_build_pull_url(url, sizeof(url), host_ip, name);
+	// Trailing slash: the destination is a directory. Without it rsync would
+	// treat a stage_dir that does not exist yet as the filename to write.
+	snprintf(dest, sizeof(dest), "%s/", stage_dir);
+	snprintf(io_timeout, sizeof(io_timeout), "--timeout=%d", WIZ_SYNC_IO_TIMEOUT_S);
+	snprintf(con_timeout, sizeof(con_timeout), "--contimeout=%d", WIZ_SYNC_CONNECT_TIMEOUT_S);
+
+	// No -r and no -l, deliberately: every transfer here is one named regular
+	// file, so there is no directory to walk and no symlink to preserve. A host
+	// that offers a symlink under a whitelisted name gets "skipping non-regular
+	// file" out of rsync itself instead of planting a link that points into the
+	// client's filesystem. -t keeps the mtime, --inplace matches sync.c and
+	// avoids a second copy on a small tmpfs, --no-perms keeps the host's mode
+	// bits off our files.
+	//
+	// argv, not a command string: the only element carrying remote input is url,
+	// and it is one element whatever bytes it holds. Its "rsync://" prefix also
+	// means it can never look like an option, whatever the name contributed.
+	char* argv[] = {(char*)RSYNC_BIN, "-t", "--inplace", "--no-perms",
+					"--info=progress2", io_timeout, con_timeout, url, dest, NULL};
+
+	if (wiz_spawn_rsync(argv, &fd, &pid) != 0)
+		return -1;
+
+	wiz_sync_render_progress(index, count, 0);
+
+	while (1) {
+		fd_set fds;
+		struct timeval tv = {0, WIZ_SYNC_POLL_US};
+		int sel;
+
+		FD_ZERO(&fds);
+		FD_SET(fd, &fds);
+
+		sel = select(fd + 1, &fds, NULL, NULL, &tv);
+		if (sel > 0) {
+			ssize_t got = read(fd, buf + len, sizeof(buf) - len);
+
+			if (got == 0) {
+				eof = true; // both ends closed: rsync has exited or is about to
+				break;
+			}
+			if (got > 0) {
+				len += (size_t)got;
+				percent = wiz_take_percent(buf, sizeof(buf), &len, percent);
+			} else if (errno != EINTR) {
+				break; // read error: rsync is still out there, kill it below
+			}
+			// EINTR falls through to the deadline check rather than restarting
+			// the loop: a signal must never buy another full iteration without
+			// the deadline being looked at.
+		} else if (sel < 0 && errno != EINTR) {
+			break;
+		}
+
+		if (percent != shown) {
+			wiz_sync_render_progress(index, count, percent);
+			shown = percent;
+		}
+
+		// The one thing that must not happen here is an unbounded wait. This
+		// loop does not poll PAD (the pull is not cancelable, symmetrically with
+		// the host's send window at wizard_net.c:754) and wizard.c holds
+		// PWR_disablePowerOff for the whole run, so a peer that stops talking
+		// mid-file would otherwise leave a device the user cannot even switch
+		// off. rsync's --timeout is the polite version of this; SIGKILL is the
+		// version that always works. Signed difference so the comparison
+		// survives SDL_GetTicks() wrapping.
+		if ((int32_t)(SDL_GetTicks() - deadline) >= 0) {
+			timed_out = true;
+			break;
+		}
+	}
+
+	close(fd);
+
+	// EOF is the ONLY exit that leaves rsync to finish on its own; a timeout, a
+	// read error and a select error all leave a child still running, and each of
+	// them used to fall into a blocking waitpid() that would never return. Every
+	// one of them now kills the process group first, and wiz_reap() bounds the
+	// wait even on the EOF path.
+	if (!eof)
+		kill(-pid, SIGKILL);
+
+	*expired = timed_out;
+
+	if (wiz_reap(pid, &status, WIZ_SYNC_REAP_GRACE_MS) != 0)
+		return -1;
+	if (!eof || timed_out)
+		return -1;
+	if (!WIFEXITED(status) || WEXITSTATUS(status) != 0)
+		return -1;
+
+	// Exit 0 is not the same as "the file is here". A host that offers a symlink
+	// under a whitelisted name gets `skipping non-regular file` out of rsync —
+	// which is the refusal we want, but rsync still exits 0, and the client would
+	// otherwise start a netplay session missing a save both sides think it has.
+	// Verified against the shipped rsync 3.2.0dev. Nothing pre-exists in the
+	// staging directory, so unlike a check against fetch_to this one cannot be
+	// satisfied by a stale file from an earlier session. Concatenation is safe
+	// here: the name passed wiz_sync_name_is_safe() before anything was spawned.
+	snprintf(dest, sizeof(dest), "%s/%s", stage_dir, name);
+	if (access(dest, F_OK) != 0)
+		return -1;
+
+	// rsync says nothing at all for a file that was already up to date, which
+	// would otherwise leave the bar wherever the last line put it.
+	wiz_sync_render_progress(index, count, 100);
+	return 0;
+}
+
+int wiz_sync_pull(const char* host_ip, const char* fetch_to,
+				  char names[][64], int name_count) {
+	char stage[WIZ_SYNC_PATH_MAX];
+	uint32_t start = SDL_GetTicks();
+	bool expired = false;
+
+	// SYNC-READY 0 is a legal offer — the host had files when it listed them and
+	// none when it served them, or a later protocol version says "nothing this
+	// round". Nothing to copy is not a failure, and standing up a transfer for
+	// zero files would only be waste. (wizard_net.c bounds n to 0..32 before it
+	// gets here, so a negative count is unreachable; reading it as "nothing to
+	// do" is still the safe way to read it.)
+	if (name_count <= 0)
+		return 0;
+
+	if (!host_ip || !fetch_to || !names) {
+		wiz_sync_error("Save transfer failed.");
+		return -1;
+	}
+
+	if (!wiz_ip_is_plain(host_ip)) {
+		wiz_sync_error("The host's address is\nnot usable.");
+		return -1;
+	}
+
+	// Before the first spawn, not per file: nothing may be fetched until every
+	// name in the set is one this file is prepared to write and to rename.
+	for (int i = 0; i < name_count; i++) {
+		if (!wiz_sync_name_is_safe(names[i])) {
+			wiz_sync_error("The host offered an\nunexpected file.");
+			return -1;
+		}
+		// ".netplay-staging" is itself a legal name under that whitelist, and a
+		// host offering it would have the commit try to rename a file over the
+		// directory it is renaming out of. Refused rather than special-cased.
+		if (strcmp(names[i], WIZ_SYNC_STAGE_DIR) == 0) {
+			wiz_sync_error("The host offered an\nunexpected file.");
+			return -1;
+		}
+	}
+
+	// A name twice is not a set, and nothing downstream dedupes. The repeat
+	// would stage one file, and then the SECOND renameat() for that name would
+	// fail with ENOENT — after the first had already replaced the local save.
+	// That is a failure reported AFTER fetch_to was modified: precisely the
+	// guarantee the staging directory exists to provide, broken deterministically
+	// by two identical lines on the wire.
+	//
+	// Refused rather than skipped. A host that read its own directory cannot
+	// produce a repeat (wizard_net.c:694 lists dirents), so a set containing one
+	// comes from a peer that is buggy or hostile, and this file has no way to
+	// tell which of the two copies it was meant to keep. Refusing costs a
+	// conforming host nothing and leaves fetch_to untouched, which silently
+	// keeping the first copy would not.
+	if (wiz_find_duplicate(names, name_count) >= 0) {
+		wiz_sync_error("The host offered the\nsame save twice.");
+		return -1;
+	}
+
+	if (wiz_stage_prepare(fetch_to) != 0) {
+		wiz_sync_error("Save transfer failed.");
+		return -1;
+	}
+
+	wiz_stage_path(stage, sizeof(stage), fetch_to);
+
+	for (int i = 0; i < name_count; i++) {
+		uint32_t elapsed = SDL_GetTicks() - start;
+		uint32_t left = (elapsed < WIZ_SYNC_TOTAL_TIMEOUT_MS)
+							? WIZ_SYNC_TOTAL_TIMEOUT_MS - elapsed
+							: 0;
+		// Both ceilings, whichever binds first. A budget already spent yields a
+		// zero-length window, which the read loop turns into an immediate
+		// timeout — the correct outcome, not a special case.
+		uint32_t window = (left < WIZ_SYNC_FILE_TIMEOUT_MS) ? left : WIZ_SYNC_FILE_TIMEOUT_MS;
+
+		if (wiz_pull_one(host_ip, stage, names[i], i, name_count,
+						 SDL_GetTicks() + window, &expired) != 0) {
+			// The whole staging directory goes, part-transferred file included.
+			// fetch_to has not been touched at all, so the client keeps exactly
+			// the saves it started with.
+			wiz_stage_purge(fetch_to);
+			wiz_sync_error(expired ? "The host stopped\nsending saves."
+								   : "Save transfer failed.");
+			return -1;
+		}
+	}
+
+	// Only now, with the whole set on disk, does anything reach fetch_to.
+	if (wiz_stage_commit(fetch_to, names, name_count) != 0) {
+		wiz_stage_purge(fetch_to);
+		wiz_sync_error("Save transfer failed.");
+		return -1;
+	}
+
+	// Empty by now; this just takes the directory itself back out of fetch_to.
+	wiz_stage_purge(fetch_to);
+	return 0;
+}

--- a/workspace/all/netplay-wizard/wizard_wifi.c
+++ b/workspace/all/netplay-wizard/wizard_wifi.c
@@ -1,0 +1,600 @@
+/*
+ * Wizard network set-up — WiFi picker and hotspot host/join.
+ *
+ * Ported from netplay/netplay_helper.c: ensureWifiEnabled +
+ * showWiFiNetworkSelection (:352-660), the hotspot host set-up (:1598-1640) and
+ * the hotspot join hygiene (:2326-2460). Behaviour is the same flow; every
+ * deliberate difference is marked "wizard:" in a comment.
+ *
+ * minarch's chrome is gone: no GFX_setMode toggling, no menu bitmap drawn
+ * behind the text, no minarch_hdmimon/beforeSleep/afterSleep — the wizard owns
+ * the screen (wiz_screen) and has no core to pause. minarch_menuMessage is
+ * replaced by wiz_error().
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "api.h"
+#include "defines.h"
+#include "keyboard.h"
+#include "network_common.h"
+#include "ui_buttonhintbar.h"
+#include "ui_list.h"
+#include "ui_message.h"
+#include "wifi_direct.h"
+#include "wizard.h"
+
+// Rescan cadence for both pickers, as in minarch's WiFi list.
+#define WIZ_SCAN_INTERVAL_MS 4000
+// Upper bound on a picker with nothing to pick: the wizard sits between the
+// launcher and the game, so it must never wait forever.
+#define WIZ_PICKER_TIMEOUT_MS 120000
+// How long an error screen stays up when the user does not dismiss it.
+#define WIZ_ERROR_TIMEOUT_MS 5000
+// DHCP lease wait after associating (minarch's 20 x 500ms).
+#define WIZ_DHCP_TIMEOUT_MS 10000
+
+#define WIZ_WIFI_MAX_NETWORKS 16
+#define WIZ_HOTSPOT_MAX 8
+#define WIZ_LABEL_MAX 96
+
+// SSID minus LINK_HOTSPOT_SSID_PREFIX (4 chars); Task 4's waiting screen shows
+// it to the joining player. Empty until wiz_hotspot_start() succeeds.
+char wiz_hotspot_code[8] = {0};
+
+//////////////////////////////////
+// Screens
+//////////////////////////////////
+
+// Transient progress text ("Connecting...", "Getting IP address..."). The
+// equivalent of netplay_helper's showOverlayMessage without the menu backdrop.
+static void wiz_status(const char* message) {
+	GFX_clear(wiz_screen);
+	UI_renderCenteredMessage(wiz_screen, message);
+	GFX_flip(wiz_screen);
+}
+
+// Stands in for minarch_menuMessage(). Difference: minarch blocks on A forever
+// because it returns to a menu; every wizard caller returns -1 straight after
+// this, which aborts the wizard and launches the game, so the screen must clear
+// itself for a user who walked away.
+static void wiz_error(const char* message) {
+	GFX_clear(wiz_screen);
+	UI_renderCenteredMessage(wiz_screen, message);
+	UI_renderButtonHintBar(wiz_screen, (char*[]){"A", "OKAY", NULL});
+	GFX_flip(wiz_screen);
+
+	uint32_t start = SDL_GetTicks();
+	while (SDL_GetTicks() - start < WIZ_ERROR_TIMEOUT_MS) {
+		GFX_startFrame();
+		PAD_poll();
+		if (PAD_justPressed(BTN_A) || PAD_justPressed(BTN_B))
+			break;
+		GFX_sync();
+	}
+}
+
+// One list screen for both pickers. UI_renderSimpleMenu draws every item it is
+// given, so the caller's list is windowed here (a scan can return more networks
+// than fit) and the slice start is handed over as the item array.
+static void wiz_render_list(const char* title, const char** labels, int count,
+							int selected, int* scroll) {
+	ListLayout layout = UI_calcListLayout(wiz_screen);
+	UI_adjustListScroll(selected, scroll, layout.items_per_page);
+
+	int visible = count - *scroll;
+	if (visible > layout.items_per_page)
+		visible = layout.items_per_page;
+
+	SimpleMenuConfig config = {
+		.title = title,
+		.items = labels + *scroll,
+		.item_count = visible,
+		.btn_b_label = "BACK",
+		.hide_controls_hint = true};
+	UI_renderSimpleMenu(wiz_screen, selected - *scroll, &config);
+	UI_renderScrollIndicators(wiz_screen, *scroll, layout.items_per_page, count);
+	GFX_flip(wiz_screen);
+}
+
+// Same frame as wiz_render_list but with no items yet, so the title bar and the
+// B hint stay put while the (blocking) scan runs.
+static void wiz_render_empty(const char* title, const char* message) {
+	SimpleMenuConfig config = {
+		.title = title,
+		.items = NULL,
+		.item_count = 0,
+		.btn_b_label = "BACK",
+		.hide_controls_hint = true};
+	UI_renderSimpleMenu(wiz_screen, 0, &config);
+	UI_renderCenteredMessage(wiz_screen, message);
+	GFX_flip(wiz_screen);
+}
+
+//////////////////////////////////
+// WiFi helpers
+//////////////////////////////////
+
+// RSSI: typically -30 (excellent) to -90 (poor).
+static const char* wiz_signal_bars(int rssi) {
+	if (rssi >= -50)
+		return "[####]";
+	if (rssi >= -60)
+		return "[### ]";
+	if (rssi >= -70)
+		return "[##  ]";
+	if (rssi >= -80)
+		return "[#   ]";
+	return "[    ]";
+}
+
+// Leading marker in a network's label.
+static const char* wiz_status_marker(const WIFI_direct_network_t* net, const char* connected_ssid) {
+	if (connected_ssid && strcmp(net->ssid, connected_ssid) == 0)
+		return "[C]"; // currently connected
+	if (net->has_saved_creds)
+		return "[*]"; // saved credentials
+	if (net->is_secured)
+		return "[L]"; // locked, needs a password
+	return "   ";	  // open
+}
+
+static bool wiz_have_ip(void) {
+	char ip[16] = {0};
+	return WIFI_direct_getIP(ip, sizeof(ip)) == 0 && ip[0] != '\0' && strcmp(ip, "0.0.0.0") != 0;
+}
+
+static bool wiz_wait_for_ip(int timeout_ms) {
+	for (int waited = 0; waited < timeout_ms; waited += 500) {
+		if (wiz_have_ip())
+			return true;
+		SDL_Delay(500);
+	}
+	return wiz_have_ip();
+}
+
+// Port of ensureWifiEnabled(). Returns false only if the WiFi stack refuses to
+// come up; the caller draws the error.
+//
+// Turning the radio on here is PERSISTENT and deliberate: WIFI_direct_ensureReady()
+// -> WIFI_enable(true) also does CFG_setWifi(true). Accepted by design — the user
+// chose a networked mode, and this matches minarch's ensureWifiEnabled(). Cleanup
+// (Task 6) restores the previous SSID *association*, never the radio power state,
+// which is also why prev_ssid == "" means "nothing to reconnect" and not "radio was
+// off". Do not add radio-state restore on top of this.
+static bool wiz_wifi_ready(void) {
+	if (WIFI_direct_isConnected())
+		return true;
+
+	// Cheap check before showing anything: a running supplicant means the stack
+	// is up and merely unassociated.
+	if (system("pidof wpa_supplicant > /dev/null 2>&1") == 0)
+		return true;
+
+	wiz_status("Enabling WiFi...");
+	return WIFI_direct_ensureReady();
+}
+
+// The SSID Task 6 restores. Must be read before anything touches the
+// association; no current connection means there is nothing to restore.
+static void wiz_record_prev_ssid(WizSession* s) {
+	if (WIFI_direct_getCurrentSSID(s->prev_ssid, sizeof(s->prev_ssid)) != 0)
+		s->prev_ssid[0] = '\0';
+}
+
+// WIFI_direct_connect() already runs udhcpc internally; this is the fallback for
+// the arm that did not connect (already-associated network) and for a lease that
+// has not landed yet.
+//
+// -n (exit when no lease) is mandatory, not a copy of netplay_helper.c's line:
+// busybox udhcpc runs in the foreground and -t caps discovers per round, not
+// rounds, so without -n it retries forever and system() never returns — with the
+// wizard holding PWR_disablePowerOff, that is a hardware-power-hold hang. Same
+// reason wifi_direct.c:48-53 passes it. This fallback only runs after
+// WIFI_direct_connect's three -n rounds already failed, i.e. almost exclusively
+// in the conditions that would hang.
+static bool wiz_ensure_ip(void) {
+	if (wiz_have_ip())
+		return true;
+
+	wiz_status("Getting IP address...");
+	system("udhcpc -i wlan0 -n -q -t 5 >/dev/null 2>&1");
+	return wiz_wait_for_ip(WIZ_DHCP_TIMEOUT_MS);
+}
+
+// Undo a failed connect attempt before leaving the picker: WIFI_direct_connect()
+// runs WIFI_selectOnly(), which disassociates and disables every other saved
+// network, so an attempt that failed leaves the client stack worse than it found
+// it. No-op when nothing was attempted (nothing was changed).
+static void wiz_restore_connection(bool attempted) {
+	if (!attempted)
+		return;
+
+	wiz_status("Restoring WiFi...");
+	WIFI_direct_restorePreviousConnection();
+}
+
+// Connect arm of the picker. 0 = associated with an IP, -1 = stay in the list
+// (message already drawn, except for a cancelled keyboard which needs none).
+// *attempted is set once WIFI_direct_connect() has run, i.e. once the caller owes
+// a wiz_restore_connection() on its way out.
+static int wiz_picker_connect(const WIFI_direct_network_t* net, const char* connected_ssid,
+							  bool* attempted) {
+	if (connected_ssid && strcmp(net->ssid, connected_ssid) == 0) {
+		wiz_status("Verifying connection...");
+		// wizard: minarch returns success here whatever the IP state, because a
+		// menu user can still fix it. The rendezvous cannot, so no IP is an error.
+		if (!wiz_ensure_ip()) {
+			wiz_error("Connected but no IP.\n\nPlease try again.");
+			return -1;
+		}
+		return 0;
+	}
+
+	if (net->has_saved_creds || !net->is_secured) {
+		wiz_status("Connecting...");
+		*attempted = true;
+		if (WIFI_direct_connect(net->ssid, NULL) != 0) { // NULL = use saved creds
+			wiz_error("Connection failed.\n\nPlease check the network\nand try again.");
+			return -1;
+		}
+	} else {
+		char* password = Keyboard_getPassword();
+		if (!password)
+			return -1; // keyboard cancelled: back to the list, nothing to report
+
+		wiz_status("Connecting...");
+		*attempted = true;
+		int ret = WIFI_direct_connect(net->ssid, password);
+		free(password);
+
+		if (ret != 0) {
+			wiz_error("Connection failed.\n\nIncorrect password or\nnetwork unavailable.");
+			return -1;
+		}
+	}
+
+	if (!wiz_ensure_ip()) {
+		wiz_error("Connected but no IP.\n\nPlease try again.");
+		return -1;
+	}
+	return 0;
+}
+
+//////////////////////////////////
+// WiFi mode
+//////////////////////////////////
+
+int wiz_wifi_ensure_connected(WizSession* s) {
+	if (!wiz_wifi_ready()) {
+		wiz_error("Failed to enable WiFi.\nPlease try again.");
+		return -1;
+	}
+
+	// Both before the picker can change anything: prev_ssid is what --cleanup
+	// restores in a later process (Task 6), saveCurrentConnection() is what
+	// wiz_restore_connection() puts back inside this one when the user leaves the
+	// picker after a failed attempt.
+	wiz_record_prev_ssid(s);
+	WIFI_direct_saveCurrentConnection();
+
+	// wizard: minarch's ensureNetworkConnected() always shows the picker so the
+	// user can confirm or switch networks. Here the user asked to launch a game,
+	// not to manage WiFi — a working connection is the answer and the picker is
+	// skipped. prev_ssid then names the network we are already on, which makes
+	// Task 6's restore a no-op.
+	if (WIFI_direct_isConnected() && wiz_have_ip())
+		return 0;
+
+	WIFI_direct_network_t networks[WIZ_WIFI_MAX_NETWORKS];
+	char label_text[WIZ_WIFI_MAX_NETWORKS][WIZ_LABEL_MAX];
+	const char* labels[WIZ_WIFI_MAX_NETWORKS];
+	int count = 0;
+	int selected = 0;
+	int scroll = 0;
+	bool dirty = true;
+	bool scanned = false;
+	bool preselected = false;
+	bool attempted = false; // a connect attempt has run WIFI_selectOnly()
+	uint32_t last_scan = 0;
+	uint32_t start_time = SDL_GetTicks();
+
+	// The SSID the list marks [C]. Read once: the picker is the only thing that
+	// can change it, and doing so returns from this function.
+	char connected_buf[WIFI_DIRECT_SSID_MAX] = {0};
+	const char* connected_ssid =
+		(WIFI_direct_getCurrentSSID(connected_buf, sizeof(connected_buf)) == 0) ? connected_buf : NULL;
+
+	while (1) {
+		uint32_t now = SDL_GetTicks();
+
+		if (now - start_time > WIZ_PICKER_TIMEOUT_MS) {
+			wiz_restore_connection(attempted);
+			wiz_error("WiFi selection timed out.\n\nPlease try again.");
+			return -1;
+		}
+
+		// wizard: minarch triggers a scan and reads the result 1.5s later. That
+		// split is dead in the current wifi_direct.c — WIFI_direct_triggerScan()
+		// is a no-op and WIFI_direct_scanNetworks() triggers, waits and reads in
+		// one blocking call — so the read happens inline. The 4s cadence is kept.
+		if (!scanned || now - last_scan >= WIZ_SCAN_INTERVAL_MS) {
+			if (!scanned)
+				wiz_render_empty("Select WiFi Network", "Scanning for networks...");
+
+			count = WIFI_direct_scanNetworks(networks, WIZ_WIFI_MAX_NETWORKS);
+			last_scan = SDL_GetTicks();
+			scanned = true;
+			dirty = true;
+
+			for (int i = 0; i < count; i++) {
+				// wizard: minarch renders "[C] ssid [####]". Marker and bars come
+				// first here because a long SSID is truncated from the right, and
+				// the markers are the part the user needs to see.
+				snprintf(label_text[i], WIZ_LABEL_MAX, "%s %s %s",
+						 wiz_status_marker(&networks[i], connected_ssid),
+						 wiz_signal_bars(networks[i].rssi), networks[i].ssid);
+				labels[i] = label_text[i];
+			}
+
+			// Pre-select the connected network, else the strongest saved one.
+			// Once only: after that the cursor belongs to the user.
+			if (count > 0 && !preselected) {
+				preselected = true;
+				int connected_idx = -1;
+				int best_saved = -1;
+				int best_rssi = -999;
+
+				for (int i = 0; i < count; i++) {
+					if (connected_ssid && strcmp(networks[i].ssid, connected_ssid) == 0)
+						connected_idx = i;
+					if (networks[i].has_saved_creds && networks[i].rssi > best_rssi) {
+						best_rssi = networks[i].rssi;
+						best_saved = i;
+					}
+				}
+
+				if (connected_idx >= 0)
+					selected = connected_idx;
+				else if (best_saved >= 0)
+					selected = best_saved;
+				else
+					selected = 0;
+			}
+
+			if (selected >= count)
+				selected = count > 0 ? count - 1 : 0;
+		}
+
+		GFX_startFrame();
+		PAD_poll();
+
+		if (PAD_justPressed(BTN_B)) {
+			// Cancelling after a failed attempt must not leave the device
+			// disassociated with its other saved networks disabled.
+			wiz_restore_connection(attempted);
+			return -2;
+		}
+
+		if (count > 0) {
+			if (PAD_justRepeated(BTN_UP)) {
+				selected = (selected + count - 1) % count;
+				dirty = true;
+			} else if (PAD_justRepeated(BTN_DOWN)) {
+				selected = (selected + 1) % count;
+				dirty = true;
+			} else if (PAD_justPressed(BTN_A)) {
+				if (wiz_picker_connect(&networks[selected], connected_ssid, &attempted) == 0)
+					return 0;
+
+				// Failed: back to the list with fresh results. The timeout budget
+				// restarts because it exists to catch an abandoned screen, and a
+				// connect attempt (keyboard entry included) is not that — minarch
+				// never restarts it, but there a timeout only closed a menu.
+				scanned = false;
+				dirty = true;
+				start_time = SDL_GetTicks();
+			}
+		}
+
+		PWR_update(&dirty, NULL, NULL, NULL);
+
+		if (dirty) {
+			if (count > 0)
+				wiz_render_list("Select WiFi Network", labels, count, selected, &scroll);
+			else
+				wiz_render_empty("Select WiFi Network", "No networks found");
+			dirty = false;
+		} else {
+			GFX_sync();
+		}
+	}
+}
+
+//////////////////////////////////
+// Hotspot mode
+//////////////////////////////////
+
+int wiz_hotspot_start(WizSession* s, const char* game) {
+	// The game title belongs to the rendezvous payload (Task 4), not to the AP:
+	// the SSID carries a random code so two nearby hosts never collide.
+	(void)game;
+
+	if (!wiz_wifi_ready()) {
+		wiz_error("Failed to enable WiFi.\nPlease try again.");
+		return -1;
+	}
+
+	// Before startHotspot() hands wlan0 to hostapd. If WiFi was off, wiz_wifi_ready()
+	// only just re-enabled it and the reconnect may not have completed — an empty
+	// prev_ssid then means Task 6 restores nothing, same as minarch's
+	// WIFI_direct_saveCurrentConnection().
+	wiz_record_prev_ssid(s);
+
+	char ssid[WIFI_DIRECT_SSID_MAX];
+	NET_HotspotConfig hotspot_cfg = {
+		.prefix = LINK_HOTSPOT_SSID_PREFIX,
+		// minarch seeds with the game CRC; the wizard has no CRC, and the pid
+		// keeps two launches in the same second apart.
+		.seed = (uint32_t)time(NULL) ^ (uint32_t)getpid()};
+	NET_generateHotspotSSID(ssid, sizeof(ssid), &hotspot_cfg);
+
+	// Purge stale hotspot networks while wpa_supplicant is still up (startHotspot
+	// kills it to hand wlan0 to hostapd). Clears entries this device accumulated
+	// from past client joins.
+	WIFI_direct_forgetAllHotspots();
+
+	wiz_status("Starting hotspot...");
+	if (WIFI_direct_startHotspot(ssid, WIFI_DIRECT_HOTSPOT_PASS) != 0) {
+		wiz_error("Failed to start hotspot.\nCheck device capabilities.");
+		return -1;
+	}
+
+	size_t prefix_len = strlen(LINK_HOTSPOT_SSID_PREFIX);
+	snprintf(wiz_hotspot_code, sizeof(wiz_hotspot_code), "%s",
+			 strlen(ssid) > prefix_len ? ssid + prefix_len : "????");
+
+	// No IP check here: the AP address (10.0.0.1) is set by startHotspot with the
+	// client stack down, and WIFI_direct_getIP() reads that client stack.
+	return 0;
+}
+
+int wiz_hotspot_join(WizSession* s) {
+	if (!wiz_wifi_ready()) {
+		wiz_error("Failed to enable WiFi.\nPlease try again.");
+		return -1;
+	}
+
+	wiz_record_prev_ssid(s);
+
+	// Purge stale hotspot networks left by previous sessions before joining a new
+	// one. Done up front (not only on teardown) so a backlog from aborted joins
+	// can't grow unbounded or let wpa_supplicant prefer an old saved hotspot.
+	WIFI_direct_forgetAllHotspots();
+
+	char hotspots[WIZ_HOTSPOT_MAX][WIFI_DIRECT_SSID_MAX];
+	char label_text[WIZ_HOTSPOT_MAX][WIZ_LABEL_MAX];
+	const char* labels[WIZ_HOTSPOT_MAX];
+	size_t prefix_len = strlen(LINK_HOTSPOT_SSID_PREFIX);
+	int count = 0;
+	int selected = 0;
+	int scroll = 0;
+	bool dirty = true;
+	bool scanned = false;
+	uint32_t last_scan = 0;
+	uint32_t start_time = SDL_GetTicks();
+	char selected_ssid[WIFI_DIRECT_SSID_MAX] = {0};
+
+	while (!selected_ssid[0]) {
+		uint32_t now = SDL_GetTicks();
+
+		// wizard: minarch scans once and gives up. This screen rescans, so the
+		// joiner can start first and wait for the host — but only for as long as
+		// there is nothing to pick. Once a code is listed the user decides.
+		if (count == 0 && now - start_time > WIZ_PICKER_TIMEOUT_MS) {
+			wiz_error("No host found.\n\nMake sure the host has\nstarted hosting first.");
+			return -1;
+		}
+
+		if (!scanned || now - last_scan >= WIZ_SCAN_INTERVAL_MS) {
+			if (!scanned)
+				wiz_render_empty("Select code shown on the host", "Scanning for hosts...");
+
+			memset(hotspots, 0, sizeof(hotspots)); // scanForHotspots leaves the tail untouched
+			// Three scan passes live inside WIFI_direct_scanForHotspots (a hotspot
+			// can take a moment to appear); it returns early once it finds one.
+			count = WIFI_direct_scanForHotspots(LINK_HOTSPOT_SSID_PREFIX, hotspots, WIZ_HOTSPOT_MAX);
+			last_scan = SDL_GetTicks();
+			scanned = true;
+			dirty = true;
+
+			for (int i = 0; i < count; i++) {
+				snprintf(label_text[i], WIZ_LABEL_MAX, "%s",
+						 strlen(hotspots[i]) > prefix_len ? hotspots[i] + prefix_len : "????");
+				labels[i] = label_text[i];
+			}
+
+			if (selected >= count)
+				selected = count > 0 ? count - 1 : 0;
+		}
+
+		GFX_startFrame();
+		PAD_poll();
+
+		if (PAD_justPressed(BTN_B))
+			return -2;
+
+		if (count > 0) {
+			if (PAD_justRepeated(BTN_UP)) {
+				selected = (selected + count - 1) % count;
+				dirty = true;
+			} else if (PAD_justRepeated(BTN_DOWN)) {
+				selected = (selected + 1) % count;
+				dirty = true;
+			} else if (PAD_justPressed(BTN_A)) {
+				strncpy(selected_ssid, hotspots[selected], sizeof(selected_ssid) - 1);
+				selected_ssid[sizeof(selected_ssid) - 1] = '\0';
+				continue;
+			}
+		}
+
+		PWR_update(&dirty, NULL, NULL, NULL);
+
+		if (dirty) {
+			if (count > 0)
+				wiz_render_list("Select code shown on the host", labels, count, selected, &scroll);
+			else
+				wiz_render_empty("Select code shown on the host", "Waiting for a host...");
+			dirty = false;
+		} else {
+			GFX_sync();
+		}
+	}
+
+	char connect_msg[64];
+	snprintf(connect_msg, sizeof(connect_msg), "Connecting to %s...",
+			 strlen(selected_ssid) > prefix_len ? selected_ssid + prefix_len : "????");
+	wiz_status(connect_msg);
+
+	// Save the current connection so the failure paths below can put it back in
+	// this process; s->prev_ssid is the copy that survives into --cleanup.
+	WIFI_direct_saveCurrentConnection();
+
+	// A device that hosted earlier still has hostapd/udhcpd running and an AP
+	// address on its interface; both stop us associating as a client. wlan1 is
+	// tg5040's boot-created AP vif — hostapd now runs on wlan0, but the vif can
+	// still hold an address from an older build.
+	system("killall hostapd 2>/dev/null");
+	system("killall udhcpd 2>/dev/null");
+	system("ip addr flush dev wlan1 2>/dev/null");
+	system("ip link set wlan1 down 2>/dev/null");
+
+	// Disconnect from current WiFi first to ensure a clean switch to the hotspot,
+	// and flush stale state (old address, old default route) that would otherwise
+	// keep us off the 10.0.0.x subnet.
+	WIFI_direct_disconnect();
+	system("ip addr flush dev wlan0 2>/dev/null");
+	system("ip route flush dev wlan0 2>/dev/null");
+	SDL_Delay(1000); // let the teardown settle before associating
+
+	if (WIFI_direct_connect(selected_ssid, WIFI_DIRECT_HOTSPOT_PASS) != 0) {
+		WIFI_direct_restorePreviousConnection(); // so the next scan works
+		wiz_error("Failed to join hotspot.");
+		return -1;
+	}
+
+	if (!wiz_have_ip()) {
+		wiz_status("Waiting for network...");
+		if (!wiz_wait_for_ip(WIZ_DHCP_TIMEOUT_MS)) {
+			WIFI_direct_restorePreviousConnection();
+			wiz_error("Failed to join hotspot.\n\nNo IP address from host.");
+			return -1;
+		}
+	}
+
+	return 0;
+}

--- a/workspace/all/nextui/content.c
+++ b/workspace/all/nextui/content.c
@@ -249,6 +249,21 @@ int hasM3u(char* rom_path, char* m3u_path) { // NOTE: rom_path not dir_path
 	return exists(m3u_path);
 }
 
+int dirGameFile(const char* dir_path, char* out_path) {
+	// A directory is a "folder game" when it contains a folder-named .cue or
+	// .m3u, e.g. /Roms/PSX/Game → /Roms/PSX/Game/Game.cue. Cue wins over m3u,
+	// matching openDirectory's auto-launch order. out_path (>= MAX_PATH)
+	// receives the resolved file — the entry's effective ROM for actions.
+	char* dir_name = strrchr(dir_path, '/');
+	if (!dir_name)
+		return 0;
+	snprintf(out_path, MAX_PATH, "%s%s.cue", dir_path, dir_name);
+	if (exists(out_path))
+		return 1;
+	snprintf(out_path, MAX_PATH, "%s%s.m3u", dir_path, dir_name);
+	return exists(out_path);
+}
+
 int canPinEntry(Entry* entry) {
 	// PAK and ROM can always be pinned
 	if (entry->type == ENTRY_PAK || entry->type == ENTRY_ROM) {
@@ -256,18 +271,8 @@ int canPinEntry(Entry* entry) {
 	}
 	// ENTRY_DIR can be pinned only if it has a .cue or .m3u file (multi-disc game)
 	if (entry->type == ENTRY_DIR) {
-		char cue_path[MAX_PATH];
-		if (hasCue(entry->path, cue_path))
-			return 1;
-		// hasM3u expects a file path, so build the m3u path directly for directories:
-		// e.g. /Roms/PSX/Game → /Roms/PSX/Game/Game.m3u
-		char* dir_name = strrchr(entry->path, '/');
-		if (dir_name) {
-			char m3u_path[MAX_PATH];
-			snprintf(m3u_path, sizeof(m3u_path), "%s%s.m3u", entry->path, dir_name);
-			return exists(m3u_path);
-		}
-		return 0;
+		char game_path[MAX_PATH];
+		return dirGameFile(entry->path, game_path);
 	}
 	return 0;
 }

--- a/workspace/all/nextui/content.h
+++ b/workspace/all/nextui/content.h
@@ -17,6 +17,7 @@ void getUniqueName(Entry* entry, char* out_name);
 int hasEmu(char* emu_name);
 int hasCue(char* dir_path, char* cue_path);
 int hasM3u(char* rom_path, char* m3u_path);
+int dirGameFile(const char* dir_path, char* out_path);
 int hasCollections(void);
 int hasRoms(char* dir_name);
 int hasTools(void);

--- a/workspace/all/nextui/gamelist.c
+++ b/workspace/all/nextui/gamelist.c
@@ -465,6 +465,33 @@ static void doRename(Entry* entry, int sel) {
 		free(newname);
 }
 
+// Netplay-capable = the entry's owning emu pak ships a "netplay" marker
+// file beside its launch.sh. Cached by path: this is called from the
+// input poll and the hint bar every frame.
+static char netplay_cap_path[MAX_PATH] = {0};
+static bool netplay_cap = false;
+static bool entryNetplayCapable(Entry* entry) {
+	if (!entry || entry->type != ENTRY_ROM)
+		return false;
+	if (!prefixMatch(ROMS_PATH, entry->path))
+		return false;
+	if (exactMatch(netplay_cap_path, entry->path))
+		return netplay_cap;
+	strncpy(netplay_cap_path, entry->path, MAX_PATH - 1);
+	netplay_cap_path[MAX_PATH - 1] = '\0';
+	netplay_cap = false;
+	char emu_name[MAX_PATH];
+	getEmuName(entry->path, emu_name);
+	char pak_path[MAX_PATH];
+	getEmuPath(emu_name, pak_path);
+	char* slash = strrchr(pak_path, '/');
+	if (slash) {
+		strcpy(slash + 1, "netplay"); // replaces "launch.sh"; same dir
+		netplay_cap = exists(pak_path);
+	}
+	return netplay_cap;
+}
+
 // Dispatch a selected context-menu item (ids assigned in GameList_handleInput).
 // Runs in nextui.c's main loop; blocking modals here are safe (the flip is
 // synchronous, and UIKeyboard_open already blocks mid-loop from Search).
@@ -523,6 +550,12 @@ void GameList_runContextAction(int id) {
 	case 34: // Add to Collection
 		if (entry && entry->type == ENTRY_ROM)
 			doAddToCollection(entry);
+		break;
+	case 35: // Launch with Netplay
+		if (entry && entryNetplayCapable(entry)) {
+			putFile(NETPLAY_LAUNCH_PATH, "1\n");
+			Entry_open(entry);
+		}
 		break;
 	default:
 		break;
@@ -601,6 +634,11 @@ GameListResult GameList_handleInput(unsigned long now, int currentScreen,
 				strncpy(items[idx].label, "Add to Collection", CONTEXTMENU_MAX_TEXT);
 				items[idx].id = 34;
 				idx++;
+				if (entryNetplayCapable(entry)) {
+					strncpy(items[idx].label, "Launch with Netplay", CONTEXTMENU_MAX_TEXT);
+					items[idx].id = 35;
+					idx++;
+				}
 			}
 		}
 
@@ -722,8 +760,15 @@ GameListResult GameList_handleInput(unsigned long now, int currentScreen,
 		Entry_open(entry);
 		*dirty = true;
 	}
-	// Y to search at root (pin/unpin now lives in the context menu)
-	else if (stack->count == 1 && PAD_justReleased(BTN_Y)) {
+	// Y launches netplay-capable ROMs with netplay (works at root for
+	// pinned games too — root Search moved to START for this)
+	else if (total > 0 && PAD_justReleased(BTN_Y) && entryNetplayCapable(entry)) {
+		putFile(NETPLAY_LAUNCH_PATH, "1\n");
+		Entry_open(entry);
+		*dirty = true;
+	}
+	// START to search at root (was Y; pin/unpin lives in the context menu)
+	else if (stack->count == 1 && PAD_justReleased(BTN_START)) {
 		if (Search_open()) {
 			result.screen = SCREEN_SEARCH;
 			result.animdir = SLIDE_LEFT;
@@ -818,7 +863,7 @@ void GameList_render(SDL_Surface* screen, int lastScreen,
 		// search hint at root
 		if (!(show_setting && !GetHDMI()) && !GetHDMI() &&
 			stack->count == 1 && total > 0) {
-			right_pairs[p++] = "Y";
+			right_pairs[p++] = "START";
 			right_pairs[p++] = "SEARCH";
 		}
 
@@ -829,24 +874,21 @@ void GameList_render(SDL_Surface* screen, int lastScreen,
 				right_pairs[p++] = "BACK";
 			}
 		} else {
-			if (resume.can_resume) {
-				if (stack->count > 1) {
-					right_pairs[p++] = "B";
-					right_pairs[p++] = "BACK";
-				}
-				right_pairs[p++] = "X";
-				right_pairs[p++] = "RESUME";
-				right_pairs[p++] = "A";
-				right_pairs[p++] = "OPEN";
-			} else if (stack->count > 1) {
+			bool netplay_hint = entryNetplayCapable(entry);
+			if (stack->count > 1) {
 				right_pairs[p++] = "B";
 				right_pairs[p++] = "BACK";
-				right_pairs[p++] = "A";
-				right_pairs[p++] = "OPEN";
-			} else {
-				right_pairs[p++] = "A";
-				right_pairs[p++] = "OPEN";
 			}
+			if (netplay_hint) {
+				right_pairs[p++] = "Y";
+				right_pairs[p++] = "NETPLAY";
+			}
+			if (resume.can_resume) {
+				right_pairs[p++] = "X";
+				right_pairs[p++] = "RESUME";
+			}
+			right_pairs[p++] = "A";
+			right_pairs[p++] = "OPEN";
 		}
 
 		if (right_pairs[0])

--- a/workspace/all/nextui/gamelist.c
+++ b/workspace/all/nextui/gamelist.c
@@ -33,6 +33,7 @@
 #include <libgen.h>
 #include <stdio.h>
 #include <string.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 static bool gl_simple_mode = false;
@@ -169,6 +170,81 @@ static void reloadDirectoryAt(int idx, int keep_selected) {
 		top = fresh;
 }
 
+// A "folder game" is an ENTRY_DIR under Roms containing a folder-named .cue
+// or .m3u (multi-disc game); opening it auto-launches disc 1, so the context
+// menu treats it like a ROM. Fills game_file_out (>= MAX_PATH) with the
+// resolved cue/m3u — the entry's effective ROM file for all actions.
+static bool entryFolderGame(Entry* entry, char* game_file_out) {
+	if (!entry || entry->type != ENTRY_DIR)
+		return false;
+	if (!prefixMatch(ROMS_PATH, entry->path))
+		return false;
+	// a console dir is a library, never a game — even if it happens to
+	// contain a playlist named after itself
+	if (isConsoleDir(entry->path))
+		return false;
+	return dirGameFile(entry->path, game_file_out) != 0;
+}
+
+// True when `path` is the folder-named .cue/.m3u of its parent dir (basename
+// minus extension == parent dir name) — the file that makes the parent a
+// folder game. Fills parent_out (>= MAX_PATH) with the parent dir path.
+static bool isFolderGameFile(const char* path, char* parent_out) {
+	if (!suffixMatch(".cue", path) && !suffixMatch(".m3u", path))
+		return false;
+	if (!prefixMatch(ROMS_PATH, path))
+		return false;
+	char work[MAX_PATH];
+	strncpy(work, path, sizeof(work) - 1);
+	work[sizeof(work) - 1] = '\0';
+	char* slash = strrchr(work, '/');
+	if (!slash)
+		return false;
+	char base[MAX_PATH];
+	strncpy(base, slash + 1, sizeof(base) - 1);
+	base[sizeof(base) - 1] = '\0';
+	char* dot = strrchr(base, '.');
+	if (dot)
+		*dot = '\0';
+	*slash = '\0'; // work = parent dir
+	// never treat a console dir as the "game folder" — a stray playlist named
+	// after the console (eg. DC/DC.m3u) must not delete the whole library
+	if (isConsoleDir(work))
+		return false;
+	char* parent_name = strrchr(work, '/');
+	if (!parent_name || !exactMatch(parent_name + 1, base))
+		return false;
+	strncpy(parent_out, work, MAX_PATH - 1);
+	parent_out[MAX_PATH - 1] = '\0';
+	return true;
+}
+
+// Depth-first recursive delete. Symlink-safe: lstat, so symlinks are
+// unlinked without ever being followed; files unlink, dirs rmdir last.
+static void removeRecursive(const char* path) {
+	struct stat st;
+	if (lstat(path, &st) != 0)
+		return;
+	if (!S_ISDIR(st.st_mode)) {
+		unlink(path);
+		return;
+	}
+	DIR* dh = opendir(path);
+	if (dh) {
+		struct dirent* dp;
+		while ((dp = readdir(dh)) != NULL) {
+			if (dp->d_name[0] == '.' && (dp->d_name[1] == '\0' ||
+										 (dp->d_name[1] == '.' && dp->d_name[2] == '\0')))
+				continue; // "." / ".."
+			char child[MAX_PATH];
+			snprintf(child, sizeof(child), "%s/%s", path, dp->d_name);
+			removeRecursive(child);
+		}
+		closedir(dh);
+	}
+	rmdir(path);
+}
+
 // A file "belongs" to base if it is exactly <base> or starts with "<base>.".
 // The trailing-dot boundary is what makes this safe: it renames Game.gba /
 // Game.png / Game.srm / Game.gba.sav / Game.state without ever touching
@@ -216,11 +292,14 @@ static bool renameRomFiles(Entry* entry, const char* newbase, char* new_path) {
 	*slash = '\0';
 	const char* filename = slash + 1;
 
-	// oldbase = filename minus final extension; ext keeps the leading dot
+	// oldbase = filename minus final extension; ext keeps the leading dot.
+	// Folder games are directories, so the whole name is the base — a dotted
+	// folder like "Game v1.1" must not be split on its last dot.
+	bool is_dir_game = entry->type == ENTRY_DIR;
 	char oldbase[MAX_PATH];
 	strncpy(oldbase, filename, sizeof(oldbase) - 1);
 	oldbase[sizeof(oldbase) - 1] = '\0';
-	const char* fdot = strrchr(filename, '.');
+	const char* fdot = is_dir_game ? NULL : strrchr(filename, '.');
 	char ext[MAX_PATH];
 	if (fdot) {
 		oldbase[fdot - filename] = '\0';
@@ -241,7 +320,28 @@ static bool renameRomFiles(Entry* entry, const char* newbase, char* new_path) {
 	char emu[MAX_PATH];
 	getEmuName(entry->path, emu);
 
-	// 1) the ROM folder itself (renames Game.gba + any Game.cue / Game.m3u)
+	// 0) folder games: rename the inner folder-named .cue/.m3u (and matching
+	// art in the folder's own .media) BEFORE the folder itself moves — the
+	// old folder path must still be valid. Discs keep their names, so
+	// cue/m3u contents that reference them stay correct.
+	if (is_dir_game) {
+		const char* game_exts[] = {".cue", ".m3u"};
+		for (int i = 0; i < 2; i++) {
+			char from[MAX_PATH];
+			snprintf(from, sizeof(from), "%s/%s%s", entry->path, oldbase, game_exts[i]);
+			if (exists(from)) {
+				char to[MAX_PATH];
+				snprintf(to, sizeof(to), "%s/%s%s", entry->path, newbase, game_exts[i]);
+				rename(from, to);
+			}
+		}
+		char inner_media[MAX_PATH];
+		snprintf(inner_media, sizeof(inner_media), "%s/.media", entry->path);
+		renameSweepDir(inner_media, oldbase, newbase);
+	}
+
+	// 1) the ROM folder itself (renames Game.gba + any Game.cue / Game.m3u,
+	// or the game folder for a folder game)
 	renameSweepDir(dir, oldbase, newbase);
 
 	// 2) box/thumbnail art
@@ -402,10 +502,13 @@ static int pickCollectionModal(Array* collections) {
 }
 
 // Append the ROM's SD-relative path to a collection .txt (deduped).
-static void addRomToCollectionFile(const char* collection_path, Entry* entry) {
-	if (!prefixMatch(SDCARD_PATH, entry->path))
+// rom_path is a file path: for folder games the caller passes the resolved
+// folder-named cue/m3u (getCollection types every non-.pak line ENTRY_ROM,
+// so a bare folder line would produce a broken entry).
+static void addRomToCollectionFile(const char* collection_path, const char* rom_path) {
+	if (!prefixMatch(SDCARD_PATH, rom_path))
 		return;
-	const char* rel = entry->path + strlen(SDCARD_PATH);
+	const char* rel = rom_path + strlen(SDCARD_PATH);
 
 	FILE* f = fopen(collection_path, "r");
 	if (f) {
@@ -428,7 +531,7 @@ static void addRomToCollectionFile(const char* collection_path, Entry* entry) {
 	}
 }
 
-static void doAddToCollection(Entry* entry) {
+static void doAddToCollection(const char* rom_path) {
 	Array* collections = getCollections();
 	int pick = pickCollectionModal(collections);
 
@@ -439,13 +542,13 @@ static void doAddToCollection(Entry* entry) {
 			mkdir_p(COLLECTIONS_PATH);
 			char coll_path[MAX_PATH];
 			snprintf(coll_path, sizeof(coll_path), "%s/%s.txt", COLLECTIONS_PATH, name);
-			addRomToCollectionFile(coll_path, entry);
+			addRomToCollectionFile(coll_path, rom_path);
 		}
 		if (name)
 			free(name);
 	} else if (pick >= 0 && pick < collections->count) {
 		Entry* coll = collections->items[pick];
-		addRomToCollectionFile(coll->path, entry);
+		addRomToCollectionFile(coll->path, rom_path);
 	}
 
 	EntryArray_free(collections);
@@ -471,15 +574,20 @@ static void doRename(Entry* entry, int sel) {
 static char netplay_cap_path[MAX_PATH] = {0};
 static bool netplay_cap = false;
 static bool entryNetplayCapable(Entry* entry) {
-	if (!entry || entry->type != ENTRY_ROM)
-		return false;
-	if (!prefixMatch(ROMS_PATH, entry->path))
+	if (!entry)
 		return false;
 	if (exactMatch(netplay_cap_path, entry->path))
 		return netplay_cap;
 	strncpy(netplay_cap_path, entry->path, MAX_PATH - 1);
 	netplay_cap_path[MAX_PATH - 1] = '\0';
 	netplay_cap = false;
+	// eligibility lands in the cache too (false for ineligible paths) so the
+	// per-frame hint bar never re-stats folder-game probes for the same entry
+	char game_file[MAX_PATH];
+	if (entry->type != ENTRY_ROM && !entryFolderGame(entry, game_file))
+		return false;
+	if (!prefixMatch(ROMS_PATH, entry->path))
+		return false;
 	char emu_name[MAX_PATH];
 	getEmuName(entry->path, emu_name);
 	char pak_path[MAX_PATH];
@@ -490,6 +598,37 @@ static bool entryNetplayCapable(Entry* entry) {
 		netplay_cap = exists(pak_path);
 	}
 	return netplay_cap;
+}
+
+// Mirrors entryNetplayCapable: an emu pak opts into the pre-launch options
+// editor by shipping options.sh beside its launch.sh. Single-slot cache
+// because the context-menu builder can ask for this repeatedly.
+static char emuopts_cap_path[MAX_PATH] = {0};
+static bool emuopts_cap = false;
+static bool entryEmuOptionsCapable(Entry* entry) {
+	if (!entry)
+		return false;
+	if (exactMatch(emuopts_cap_path, entry->path))
+		return emuopts_cap;
+	strncpy(emuopts_cap_path, entry->path, MAX_PATH - 1);
+	emuopts_cap_path[MAX_PATH - 1] = '\0';
+	emuopts_cap = false;
+	// eligibility lands in the cache too — see entryNetplayCapable
+	char game_file[MAX_PATH];
+	if (entry->type != ENTRY_ROM && !entryFolderGame(entry, game_file))
+		return false;
+	if (!prefixMatch(ROMS_PATH, entry->path))
+		return false;
+	char emu_name[MAX_PATH];
+	getEmuName(entry->path, emu_name);
+	char pak_path[MAX_PATH];
+	getEmuPath(emu_name, pak_path);
+	char* slash = strrchr(pak_path, '/');
+	if (slash) {
+		strcpy(slash + 1, "options.sh"); // replaces "launch.sh"; same dir
+		emuopts_cap = exists(pak_path);
+	}
+	return emuopts_cap;
 }
 
 // Dispatch a selected context-menu item (ids assigned in GameList_handleInput).
@@ -536,25 +675,76 @@ void GameList_runContextAction(int id) {
 		}
 		break;
 	case 32: // Delete Rom
-		if (entry && entry->type == ENTRY_ROM) {
+		if (entry) {
+			char game_file[MAX_PATH];
+			char parent_dir[MAX_PATH];
+			bool folder_game = entryFolderGame(entry, game_file);
+			if (entry->type != ENTRY_ROM && !folder_game)
+				break;
 			if (confirmModal("Delete ROM?", entry->name)) {
-				unlink(entry->path);
+				if (folder_game)
+					removeRecursive(entry->path);
+				else if (isFolderGameFile(entry->path, parent_dir))
+					// the folder-named cue/m3u IS the game (eg. selected from a
+					// collection): take the whole folder, don't orphan the discs
+					removeRecursive(parent_dir);
+				else
+					unlink(entry->path);
 				reloadDirectoryAt(stack->count - 1, sel);
 			}
 		}
 		break;
 	case 33: // Rename Rom
-		if (entry && entry->type == ENTRY_ROM)
-			doRename(entry, sel);
+		if (entry) {
+			char game_file[MAX_PATH];
+			if (entry->type == ENTRY_ROM || entryFolderGame(entry, game_file))
+				doRename(entry, sel);
+		}
 		break;
 	case 34: // Add to Collection
-		if (entry && entry->type == ENTRY_ROM)
-			doAddToCollection(entry);
+		if (entry) {
+			char game_file[MAX_PATH];
+			if (entry->type == ENTRY_ROM)
+				doAddToCollection(entry->path);
+			else if (entryFolderGame(entry, game_file))
+				// collections hold file paths: write the resolved cue/m3u
+				doAddToCollection(game_file);
+		}
 		break;
 	case 35: // Launch with Netplay
 		if (entry && entryNetplayCapable(entry)) {
+			// snapshot before Entry_open: its directory fall-through can
+			// rebuild the stack and free entry
+			bool was_dir = entry->type == ENTRY_DIR;
 			putFile(NETPLAY_LAUNCH_PATH, "1\n");
 			Entry_open(entry);
+			// folder games launch via openDirectory's auto-launch; if that
+			// fell through (eg. empty m3u) nothing was queued and the flag
+			// would stay armed until next boot — disarm it
+			if (was_dir && !quit)
+				unlink(NETPLAY_LAUNCH_PATH);
+		}
+		break;
+	case 36: // Emulator Options (pre-launch editor)
+		if (entry && entryEmuOptionsCapable(entry)) {
+			// folder games: hand options.sh the resolved cue/m3u, not the
+			// folder (a dotted folder name would derive a different rom key),
+			// but keep last_path on the folder so loadLast reselects it
+			char game_file[MAX_PATH];
+			char* rom_arg = entry->path;
+			if (entry->type == ENTRY_DIR && entryFolderGame(entry, game_file))
+				rom_arg = game_file;
+			char emu_name[MAX_PATH];
+			getEmuName(entry->path, emu_name);
+			char pak_path[MAX_PATH];
+			getEmuPath(emu_name, pak_path);
+			char* slash = strrchr(pak_path, '/');
+			if (slash) {
+				strcpy(slash + 1, "options.sh"); // replaces "launch.sh"; same dir
+				// options.sh cd's to its own dir, so it must be invoked by the
+				// absolute path getEmuPath already produced.
+				openScript(pak_path, rom_arg, entry->path);
+			}
 		}
 		break;
 	default:
@@ -624,7 +814,8 @@ GameListResult GameList_handleInput(unsigned long now, int currentScreen,
 				}
 				idx++;
 			}
-			if (entry->type == ENTRY_ROM) {
+			char game_file[MAX_PATH];
+			if (entry->type == ENTRY_ROM || entryFolderGame(entry, game_file)) {
 				strncpy(items[idx].label, "Delete Rom", CONTEXTMENU_MAX_TEXT);
 				items[idx].id = 32;
 				idx++;
@@ -637,6 +828,11 @@ GameListResult GameList_handleInput(unsigned long now, int currentScreen,
 				if (entryNetplayCapable(entry)) {
 					strncpy(items[idx].label, "Launch with Netplay", CONTEXTMENU_MAX_TEXT);
 					items[idx].id = 35;
+					idx++;
+				}
+				if (entryEmuOptionsCapable(entry)) {
+					strncpy(items[idx].label, "Emulator Options", CONTEXTMENU_MAX_TEXT);
+					items[idx].id = 36;
 					idx++;
 				}
 			}
@@ -763,8 +959,14 @@ GameListResult GameList_handleInput(unsigned long now, int currentScreen,
 	// Y launches netplay-capable ROMs with netplay (works at root for
 	// pinned games too — root Search moved to START for this)
 	else if (total > 0 && PAD_justReleased(BTN_Y) && entryNetplayCapable(entry)) {
+		// snapshot before Entry_open: its directory fall-through can rebuild
+		// the stack and free entry
+		bool was_dir = entry->type == ENTRY_DIR;
 		putFile(NETPLAY_LAUNCH_PATH, "1\n");
 		Entry_open(entry);
+		// folder games: disarm if the auto-launch fell through (see case 35)
+		if (was_dir && !quit)
+			unlink(NETPLAY_LAUNCH_PATH);
 		*dirty = true;
 	}
 	// START to search at root (was Y; pin/unpin lives in the context menu)
@@ -929,8 +1131,33 @@ void GameList_render(SDL_Surface* screen, int lastScreen,
 					screen, &item_layout, font.large,
 					display_text, truncated, y, row_is_selected, 0);
 				int text_width = pos.pill_width - SCALE1(BUTTON_PADDING * 2);
+				// This call site is the only place list_scroll resyncs (via
+				// ScrollText_update's strcmp), so while it's gated off below a
+				// context action that changes the selection (Delete/Rename Rom,
+				// Remove Game, Pin, Tools, Refresh) would leave the state
+				// describing the *old* title at the *old* row — and the guard
+				// frames after close would then animate that stale band over the
+				// correct list. Drop the state instead: ScrollText_clear empties
+				// text and needs_scroll, so GameList_scrollBusy() goes false and
+				// ScrollText_animateOnly cannot fire until a real (ungated)
+				// ScrollText_render has refreshed last_x/last_y/last_font. Note
+				// ScrollText_reset would NOT be safe here — it leaves
+				// needsRender() true with those last_* fields stale.
+				if (row_is_selected && ContextMenu_isOpen() &&
+					strcmp(list_scroll.text, display_text) != 0)
+					ScrollText_clear(&list_scroll);
+				// Freeze the marquee while the context menu is up: its GPU path
+				// presents the screen itself (ScrollText_render ->
+				// GFX_scrollTextTexture -> PLAT_GPU_Flip), so it would show one
+				// full vsync frame *after* nextui.c cleared LAYER_OVERLAY but
+				// *before* ContextMenu_render — the undimmed, menu-less list =
+				// a full-screen flash on every keypress. Passing NULL takes the
+				// static/truncated path (no present), which is also the correct
+				// modal behaviour. Same class of bug as 81a0c40a.
 				UI_renderListItemText(screen,
-									  row_is_selected ? &list_scroll : NULL,
+									  (row_is_selected && !ContextMenu_isOpen())
+										  ? &list_scroll
+										  : NULL,
 									  display_text, font.large,
 									  pos.text_x, pos.text_y, text_width, row_is_selected);
 			}

--- a/workspace/all/nextui/launcher.c
+++ b/workspace/all/nextui/launcher.c
@@ -203,6 +203,24 @@ void openPak(char* path) {
 	snprintf(cmd, sizeof(cmd), "'%s/launch.sh'", escapeSingleQuotes(escaped_path, sizeof(escaped_path)));
 	queueNext(cmd);
 }
+void openScript(char* script_path, char* arg, char* last_path) {
+	// Tools-style round trip: run a pak script and come back to this list
+	// position (saveLast is what loadLast() restores from on relaunch).
+	saveLast(last_path);
+
+	// escapeSingleQuotes modifies its buffer, so use separate copies.
+	char escaped_script[MAX_PATH];
+	strncpy(escaped_script, script_path, sizeof(escaped_script) - 1);
+	escaped_script[sizeof(escaped_script) - 1] = '\0';
+
+	char escaped_arg[MAX_PATH];
+	strncpy(escaped_arg, arg, sizeof(escaped_arg) - 1);
+	escaped_arg[sizeof(escaped_arg) - 1] = '\0';
+
+	char cmd[MAX_PATH * 2];
+	snprintf(cmd, sizeof(cmd), "'%s' '%s'", escapeSingleQuotes(escaped_script, sizeof(escaped_script)), escapeSingleQuotes(escaped_arg, sizeof(escaped_arg)));
+	queueNext(cmd);
+}
 void openRom(char* path, char* last) {
 	LOG_info("openRom(%s,%s)\n", path, last);
 

--- a/workspace/all/nextui/launcher.h
+++ b/workspace/all/nextui/launcher.h
@@ -46,6 +46,7 @@ int autoResume(void);
 
 // Game launching
 void openPak(char* path);
+void openScript(char* script_path, char* arg, char* last_path);
 void openRom(char* path, char* last);
 void Entry_open(Entry* self);
 

--- a/workspace/all/nextui/nextui.c
+++ b/workspace/all/nextui/nextui.c
@@ -153,8 +153,12 @@ int main(int argc, char* argv[]) {
 				dirty = true;
 			} else if (cmr.action != CONTEXTMENU_NONE) {
 				dirty = true; // redraw underlying screen after close
-			} else if (PAD_anyJustPressed()) {
-				// Redraw overlay only when navigating (selection changed)
+			} else if (PAD_anyJustPressed() || PAD_justRepeated(BTN_UP) ||
+					   PAD_justRepeated(BTN_DOWN)) {
+				// Redraw overlay only when navigating (selection changed).
+				// ContextMenu_handleInput moves cm_selected via PAD_navigateMenu,
+				// which fires on PAD_justRepeated — a held direction changed the
+				// selection with no redraw until the next unrelated dirty event.
 				dirty = true;
 			}
 		}
@@ -342,11 +346,19 @@ int main(int argc, char* argv[]) {
 				SDL_FreeSurface(tmpOldScreen);
 
 			dirty = false;
-		} else if (folderbgchanged || thumbchanged || GameList_scrollBusy()) {
+		} else if (folderbgchanged || thumbchanged ||
+				   (GameList_scrollBusy() && !ContextMenu_isOpen())) {
 			updateBackgroundLayer(blackBG);
 			renderThumbnail(1, false);
+			// Same flash as the dirty pass (see gamelist.c / 81a0c40a): the idle
+			// marquee tick presents the screen itself (ScrollText_animateOnly ->
+			// GFX_scrollTextTexture -> PLAT_GPU_Flip), which would blink the
+			// marquee band out from under the context menu's scrim. Gate the
+			// scrollBusy *term* too, not just the tick: needs_scroll stays
+			// latched while the menu is open, so an otherwise-idle loop must
+			// fall through to the sleeping path below instead of spinning here.
 			if (currentScreen != SCREEN_GAMESWITCHER &&
-				currentScreen != SCREEN_SEARCH) {
+				currentScreen != SCREEN_SEARCH && !ContextMenu_isOpen()) {
 				GameList_scrollTickIdle();
 			} else {
 				SDL_Delay(16);

--- a/workspace/all/nextui/nextui.c
+++ b/workspace/all/nextui/nextui.c
@@ -73,6 +73,11 @@ static SDL_Surface* blackBG = NULL;
 // Game list screen (input + render) lives in gamelist.c
 
 int main(int argc, char* argv[]) {
+	// Must precede autoResume(): that path returns before the rest of init, so
+	// a stale flag would ride into the auto-resumed game as a silent netplay
+	// launch. Stale = a previous launch never consumed it.
+	unlink(NETPLAY_LAUNCH_PATH);
+
 	if (autoResume())
 		return 0; // nothing to do
 

--- a/workspace/all/other/flycast/README.md
+++ b/workspace/all/other/flycast/README.md
@@ -638,6 +638,358 @@ Mode is active — upstream behavior, not something this pak adds or can route
 around. The overlay's Save/Load actions will fail silently in that mode.
 Accepted as v1 behavior.
 
+## Netplay (GGPO + DCNet)
+
+Flycast v2.6 ships two unrelated online mechanisms; both are compiled into
+our binaries already (GGPO builds unconditionally under `if(NOT LIBRETRO)`,
+`CMakeLists.txt`; DCNet is `core/network/dcnet.cpp`). No patch changes were
+needed — the overlay's `Netplay` section (`overlay_settings.json`) plus the
+seeded `[network]` block in the `default-*.cfg` files are the entire
+integration.
+
+**GGPO** — rollback netplay between two flycast instances running the same
+game (Dreamcast console games included — `ggpo.cpp` has an explicit console
+path). Peers sync inputs over **UDP 19713** and re-simulate on rollback.
+Config lives in `emu.cfg` `[network]`:
+
+```ini
+[network]
+GGPO = yes          # overlay: "GGPO Netplay"
+ActAsServer = yes   # host/P1 on one device, no (join/P2) on the other
+GGPODelay = 0       # overlay: "Input Delay" — 2-3 trades latency for fewer rollback hitches
+server = 192.168.x.x  # auto-written by launch.sh discovery; manual fallback only
+EnableUPnP = no     # forced by launch.sh on every GGPO launch (see below)
+```
+
+Constraints, all verified in source:
+- The handshake exchanges MD5s of **BIOS + game + flash/VMU state**
+  (`ggpo.cpp:537`) and fails with "Peer verification failed" on mismatch.
+  launch.sh automates the state match ("host brings the memory card"):
+  the host plays on its **real** VMU/flash and serves a tar of exactly
+  the hashed files (`vmu_save_*.bin` + `dc_nvmem.bin`, hashed per
+  `maple_cfg.cpp:381` / `nvmem.cpp:267`) over a small HTTP server on
+  **TCP 19714** — busybox `httpd` where the firmware provides it
+  (tg5040), `python3 -u -m http.server` on tg5050 (its busybox 1.35
+  lacks the httpd applet), fail-open if neither exists; the client
+  pulls it into an isolated `netplay-data/` dir
+  (`XDG_DATA_HOME` override) and plays on the borrowed copy, so the
+  client's real saves are never touched and whoever hosts contributes
+  their own unlocks. The host snapshots its card to `netplay-backup/`
+  (one-deep) before each session. Only `dc_boot.bin` and the CHD must
+  still be byte-identical on both cards by hand — BIOS and game images
+  are never synced.
+- IP setup is automatic too, and **symmetric**. GGPO is peer-to-peer, so
+  each side has to know the other's address (`ggpo.cpp:579-597`): an
+  empty `server =` makes flycast target loopback on `localPort ^ 1` —
+  `127.0.0.1:19712` from the host, `127.0.0.1:19713` from the client
+  (`ggpo.cpp:584-590`, `:808-811`) — and wait
+  forever on "Starting Network", which has no timeout — the modal's
+  Cancel button is the only way out (`gui.cpp:1286`). So **both** devices
+  serve a two-line `netplay-info` on **TCP 19714** (line 1 the ROM
+  filename with its extension stripped, line 2 the role, `host` or
+  `client`), and **both** scan the
+  LAN for a peer serving the same ROM in the *opposite* role: the ROM
+  line prevents cross-game pairing, the role line prevents two hosts (or
+  two clients) from pairing. Each side tries the stored `[network]
+  server =` first, but **only when the device holds a /24 lease and that
+  address falls inside it**. Two things follow. After moving to a
+  different network the stored address belongs to the old one and can
+  never answer, so it is skipped instead of burning ~3 s on a dead
+  probe. And on a **non-/24 lease** the subnet is never parsed at all —
+  the address is read with `sed -n 's|.*inet \([0-9.]*\)/24 .*|\1|p'`,
+  which matches nothing on a /16 or /23 — so there the stored address is
+  skipped *unconditionally*, not merely when the octets differ. A repeat
+  session on the same /24 with an unchanged DHCP lease still pairs
+  almost instantly. Otherwise it ping-sweeps its own /24 and probes the
+  `ip neigh` neighbors **concurrently** (one background probe per
+  candidate, results collected through a hits dir), so a pass costs a
+  fixed ~7 s — a 3 s settle after the sweep plus a 4 s collect, extended
+  only by the slowest straggler probe, each of which is bounded by the
+  fetch watchdog at 3 s — rather than ~1 s per reachable host. Scan time
+  no longer scales with how busy the LAN is.
+
+  Two details here are load-bearing, and the first real pair test failed
+  because neither was in place. Candidates are **deduplicated by MAC**
+  before probing: the sweep itself leaves an ARP entry for every address
+  it touched, and a router that answers ARP for unused addresses turns
+  that into hundreds of phantom neighbours sharing a handful of MACs
+  (measured on a home LAN: 22 entries before a sweep, 259 after, ~19 real
+  MACs). Probing all of them swamps a 4-core handheld and nothing
+  finishes inside the collect window. And `nx_fetch` names each download
+  with `mktemp` rather than the pid: in POSIX sh `$$` keeps the *parent*
+  shell's pid inside a subshell, so a pid-derived name is literally the
+  same file in every concurrent probe — one probe's cleanup deletes
+  another's payload, and a dead host can `cat` a live host's answer and
+  win the selection. Concurrency is what made both of these reachable;
+  neither could bite while probes ran serially. All of it is bounded by a
+  90 s wall-clock deadline. Whoever resolves a peer writes its IP back
+  to `server =`, which stays a manual fallback
+  for LANs where discovery fails — with one caveat on a non-/24 lease,
+  where the fast path never probes it: a hand-set `server =` is then
+  reached only if that host happens to sit in the `ip neigh` table, and
+  nothing sweeps to populate that table off a /24. flycast still reads
+  the hand-set value and can connect on it (launch.sh leaves it alone
+  when discovery finds nothing), but the client will not have pulled the
+  save tar — the GGPO connection and the state sync part ways there.
+  **Launch order does not matter** —
+  either device may start first, with any gap up to the deadline. On top
+  of this shared discovery, the host additionally serves the VMU/flash
+  tar and the client additionally pulls it. Every failure path fails open
+  into a normal launch so GGPO surfaces errors visibly.
+- A discovery long enough to be worth covering is no longer a silent
+  black screen. (A fast one still is, and correctly so — see the end of
+  this bullet.) While the netplay
+  block runs, launch.sh drives the already-shipped `show2.elf` in daemon
+  mode — resolved bare via `PATH`, exactly like the scripts' other helper
+  binaries, so nothing new was built. The opening "starting" message is
+  the daemon's own `--text=` argument (the FIFO does not exist yet at
+  that point); from there on launch.sh pushes `TEXT:` lines over
+  `/tmp/show2.fifo` at each stage: preparing saves (host, `TEXT:` only —
+  it carries no `PROGRESS:`, so no percentage is left standing in front
+  of the long wait that follows), looking for the peer — the host names
+  the `<subnet>.x` it is scanning, or "the network" when it holds no /24
+  lease to name — then peer found at `<ip>`, which on
+  the client is a **single** combined `host found at <ip> - copying
+  saves...` message rather than two updates (plain ASCII hyphen — a
+  tester matches these against the screen), or "starting anyway" when
+  nothing turned up. `PROGRESS:` rides along only where it means
+  something: `-1` (the marquee again) for the open-ended search, a real
+  percentage once a peer is resolved or the search has given up.
+  Sent is not the same as seen. Which message is on screen at any moment
+  is not something the design pins down: each write is *queued* from its
+  own background subshell polling for the FIFO on an independent 1 s
+  cadence, so any of the messages racing show2's init may end up the
+  survivor; and the terminal messages are followed immediately by a
+  `killall -9` that destroys the daemon, leaving them a frame at most. It
+  follows that the screen will ordinarily disappear still showing a
+  search message. The client's "copying saves" is the one update that is
+  reliably readable, because the tar fetch follows it — ~1-2 s for a
+  ~384 KB card over LAN (derived), the 30 s in `nx_fetch` being only the
+  watchdog ceiling for a host that stalls. Read the screen as evidence
+  that discovery is running, not as a progress transcript. And note the
+  corollary: on the repeat-session fast path the stored-`server =` probe
+  resolves in about a second, so the whole block can finish about as fast
+  as show2 comes up — expect a brief flash, or nothing at all. Either is
+  the feature working: there was barely a wait to cover. The screen
+  takes exactly **one** input — B skips netplay (next bullet), which is
+  why a second line sits under the status text — and is otherwise
+  informational: nothing else on it is interactive and it has no other
+  effect on what discovery does. It runs with
+  `--image=/dev/null` (there is no netplay artwork — the repo's existing
+  "no logo" idiom) and `--progress=-1`, show2's indeterminate marquee,
+  because the wait has no knowable length. `/dev/null` is accepted at
+  runtime: `IMG_Load` logs "not a regular file or pipe" and rendering
+  carries on (measured, Brick, 2026-07-29). show2 paints nothing until
+  its SDL2/DRM init finishes, and only creates its FIFO after that
+  (`mkfifo` is the first thing `runDaemonMode()` does after unlinking any
+  stale node) — **measured at ≤1 s** on tg5040 over three cold runs, so
+  only the first moment of a netplay launch is dark. Teardown must use
+  `killall -9`: show2 handles SIGINT only (`show2.cpp:623`) and `SDL_Init`
+  traps SIGTERM into an `SDL_QUIT` event its daemon loop never pumps, so
+  a plain `killall` leaves it running (measured alive 6 s later) and
+  holding the display against flycast. Everything
+  degrades silently: no `show2.elf` on `PATH`, or a daemon that died,
+  means no status screen and an otherwise-normal launch — exactly the
+  old silent behavior — and every FIFO write happens inside a background
+  subshell so a half-dead daemon can never stall the launch. Verified on
+  hardware at the function level only (start / update / stop / no-op when
+  absent, Brick 2026-07-29; the deployed tg5050 binary separately shown
+  to start, create its FIFO in ~1 s and take `TEXT:`/`PROGRESS:`
+  updates). No one has yet watched it driven by a real game launch on
+  either device.
+- **Press B during discovery to skip netplay — for that run only.** The
+  status screen's second line reads `B = skip netplay`, and pressing B
+  stops the search and launches the game single-player. The window is
+  the whole netplay block: `nx_cancel_arm` runs immediately after the
+  screen is started, before any network work, and the flag survives
+  until `nx_cancel_disarm` runs on the far side of the block, just
+  before flycast is started. It is checked at every phase boundary —
+  after the host has snapshotted and served its VMU tar, after the
+  client has published its identity, on entry to each discovery pass
+  and before each neighbour probe — and *inside* the network waits as
+  well: `nx_fetch`'s own watchdog polls it once a second, so a press
+  during the client's tar download (watchdog ceiling 30 s) is acted on
+  within about a second instead of after the download finishes. "Skip"
+  means **this run only**. launch.sh starts flycast with `-config
+  network:GGPO=no`; flycast stores a `-config` value as a **virtual**
+  setting — `get_entry()` prefers virtual values and `ConfigFile::save()`
+  never writes them (`cl.cpp` → `cfgSetVirtual`, `ini.cpp`) — so
+  `emu.cfg` is left untouched: `[network] GGPO` is still `yes`
+  afterwards and the next launch attempts netplay again. A cancelled
+  client also skips the `XDG_DATA_HOME` redirect, so it plays on its
+  **own** VMU rather than the host's borrowed copy (with GGPO off there
+  is nothing to isolate; its real saves were never at risk either way).
+  The screen shows `Skipped - starting game...` for a beat first — the
+  one-second pause on the cancel path exists only so that message can
+  be painted at all, since `nx_ui` merely *queues* its write and
+  `nx_ui_stop` kills the daemon two lines later; a press early enough to
+  precede show2's FIFO still cancels, it just cannot be confirmed on
+  screen. One residual: `[input] device2 = 0` is written unconditionally
+  at the top of the block and no cancel path reverts it, so it stays
+  until a launch with GGPO **off** puts it back to `10`.
+- How the press is read, and what the design deliberately leaves
+  behind. The hint line is show2's new **optional `--hint`** argument: a
+  second line drawn under the status text in `renderSimple()` — which
+  `renderProgress()` calls, so both display modes get it — and skipped
+  entirely when the argument is absent, so the first-boot install
+  splash, which is the same binary, renders exactly as before. B is js0
+  event **number `00`**, measured on **both** units — five consecutive
+  presses on each, every one type `01` number `00` with a non-zero
+  value, the Smart Pro S reading identical to the Brick — which agrees
+  with this pak's own `SDL_Xbox 360 Controller.cfg` (`bind0 =
+  0:btn_b`). So the one shared constant is right for both and the
+  byte-identical block needs no per-device handling. An earlier reading
+  of `02` came from a block-buffered reader that misattributed delayed
+  events and must not be restored.
+  The reader opens `/dev/input/js0` **once** on fd 3 and then runs one
+  short-lived `dd bs=8 count=1 <&3 | hexdump` per event, so hexdump
+  exits — and therefore flushes — every time. Both obvious alternatives
+  were tried on-device and fail: a persistent `dd | hexdump | while
+  read` pipeline block-buffers (~4 KB, ~170 events) and recorded zero
+  presses across a 45 s capture, and a `count=1` loop that re-opens the
+  device replays joydev's init burst on every pass and spins. Nothing
+  but a real press can trip it: the init burst is type 81/82 with value
+  0, releases carry value 0, and stick motion is type 02. If js0 is
+  unreadable the watcher exits at once and cancel is simply unavailable
+  — every other path is unchanged. Killing the watcher does **not**
+  reap its `dd`/`hexdump` children, and that leak is accepted on
+  purpose. It clears itself: the `dd` has `count=1`, so the first
+  controller event after the game starts ends it, hexdump then EOFs, and
+  joydev gives each opener an independent event buffer so nothing is
+  taken from flycast meanwhile. Both sweeps that would clean it up are
+  wrong — matching `/proc/<pid>/cmdline` cannot work (the device is a
+  redirection, never an argument; verified on-device to find none of the
+  holders), and matching open descriptors does find them all but "kill
+  whatever holds js0" would also hit `keymon.elf`, which opens input
+  devices for the whole session, or the launcher, and killing the
+  launcher powers this device off.
+- What has actually been tested (2026-07-29) — bench level, both
+  devices. The shipped helpers pass 12/12 checks on the Brick, run
+  against the functions extracted verbatim from launch.sh: arm/disarm
+  lifecycle, a stale flag cleared by `nx_cancel_arm`, the flag honoured,
+  and `nx_fetch` returning empty 2 s into a 30 s timeout when the flag
+  appears (the check that proves a press during the tar download is
+  acted on promptly). The rebuilt show2 was watched on hardware
+  rendering two lines, with the hint persisting across `TEXT:` updates
+  and the marquee animating, freezing on a numeric `PROGRESS:` and
+  re-arming on a later `PROGRESS:-1`; the no-`--hint` install-splash
+  invocation was unaffected. Both rebuilt binaries are now **deployed**
+  (Brick md5 `2678718c` → `4be3ac43`, Smart Pro S `fe7d510b` →
+  `c943d4b7`, each md5-verified against the local build, and `show2.elf`
+  resolves bare via `PATH` on both); the pre-change binary is kept
+  on-device as `show2.elf.orig` beside it, so rolling the shared install
+  splash back needs no computer. The deployed tg5050 copy was then run
+  with `--hint` on the Smart Pro S — a platform that had never run show2
+  at all — and starts, creates its FIFO in ~1 s, accepts `TEXT:` and
+  `PROGRESS:` updates and stays alive. **Not** tested, all three needing
+  a real session: an actual B press during a real game launch — that it
+  cancels, lands in single-player and leaves `[network] GGPO = yes`
+  afterwards — which cannot be driven over adb, since input cannot be
+  injected; any two-device pair test with the new block on both units;
+  and the cancelled-client-plays-on-its-own-saves path, which is
+  code-verified and reasoned but never exercised in a session.
+- Netplay launches also plug a controller into Dreamcast **port B**:
+  launch.sh sets `[input] device2 = 0` (`MDT_SegaController`) while GGPO
+  is on, automatically on both devices, and puts it back to `10`
+  (`MDT_None`) when GGPO is off, so single-player sessions see the stock
+  one-pad Dreamcast. GGPO **always drives port B as player 2** — the
+  remote player on the host, the *local* player on the client
+  (`ggpo.cpp:500`/`:569` set the local player to `localPlayerNum + 1`,
+  and `ggpo.cpp:643-650` writes `inputState[player]` straight to the
+  maple port index) — so both machines need a pad there. flycast leaves
+  port B empty by default (`option.cpp:197-201`, enum
+  `maple_cfg.h:6-18`), so those inputs reached no maple device at all —
+  MvC2's VS mode stayed greyed out and the second device's Start did
+  nothing (that device's *own* player is port B). **Both
+  peers must carry the identical value** or the emulated machines differ
+  and desync; that is why launch.sh owns the key on both sides rather
+  than leaving it to a hand edit. A bare controller on port B does not
+  perturb the GGPO verification digest — `vmuDigest()`
+  (`maple_cfg.cpp:364`) only hashes devices whose `getData()` is
+  non-null.
+- Security posture: the rendezvous is deliberately unauthenticated
+  (home-LAN scope). While netplay is on, the serve dir is readable by
+  any device on the network for the session's duration — on the host
+  that is the `netplay-info` identity file plus the VMU/flash tar, on
+  the client only `netplay-info` (the python3 branch also
+  directory-indexes the dir; the server writes no request log at all —
+  busybox `httpd` runs without `-v` — and the stdout/stderr file it does
+  write lives outside the serve dir, so nothing there is served). Note
+  what that tar actually contains: `data/flycast` is shared by **all**
+  Dreamcast games, so the host serves its **entire VMU set** (every
+  `vmu_save_*.bin` plus `dc_nvmem.bin`), not just the saves of the game
+  being played. Outbound, every netplay-on launch **ping-sweeps all 254
+  addresses of the local /24 repeatedly and HTTP-GETs each neighbor**
+  for up to 90 s; on a network that is not your own home LAN that
+  traffic reads as a port scan. Inbound, the client
+  extracts a synced tar only when all **five** guard conditions hold:
+  the file is non-empty; `tar tf` lists at least one entry (a non-tar
+  payload lists nothing, which would pass every negated test
+  vacuously); every name is a bare allowlisted filename (no slashes,
+  no `..`, no absolute paths); every `tar tvf` mode column is `-`; and
+  no entry is a link (` -> `). The link test is not redundant with the
+  mode column: busybox tar prints a HARDLINK with a leading `-`, so on
+  this firmware the mode column alone would accept one. Verdicts on
+  device (Brick, busybox 1.27.2): good tar ACCEPT; path-traversal,
+  symlink, hardlink, non-tar junk and empty all REJECT. A hostile peer
+  can at worst replace the client's netplay-data VMU copies, never
+  write outside them.
+- **UPnP is forced off** on every GGPO launch: launch.sh writes
+  `[network] EnableUPnP = no`. flycast defaults it to **true**
+  (`option.cpp:172`) and `ggpo.cpp:801-804` runs `miniupnp.Init()` +
+  `AddPortMapping(19713/UDP)` *before* the `ActAsServer` branch, so
+  **both** roles would otherwise punch a router mapping with an 86400 s
+  lease (`miniupnp.cpp`). The `EnableUPnP = no` seeded in the
+  `default*.cfg` files only reaches **fresh installs** (they're gated
+  behind `.initialized`), so writing it from launch.sh is what closes it
+  on already-installed devices. There is no restore-when-off branch —
+  the value is only read on the GGPO path.
+- **Pairing key gotcha:** peers match on the ROM **filename with its
+  extension stripped** (`EMU_OVERLAY_GAME`), *not* on CHD content. Two
+  byte-identical CHDs stored under different filenames will never pair,
+  and the symptom is thin: the status screen sits for the full 90 s on
+  whatever message survived show2's init window — "looking for the host"
+  on the client, either "preparing saves" or "looking for player 2 …" on
+  the host — then simply
+  disappears, because the "starting anyway" update is queued and killed
+  before it can be read. flycast then drops into its untimed "Starting
+  Network". Nothing names the mismatch. Keep the game file named
+  identically on both cards.
+- **Leave flycast's `PerGameVmu` off.** With it on, the port-A1 VMU file
+  is written as `<gameId>_vmu_save_A1.bin` (`oslib.cpp:52-66`) — a name
+  the host's `tar cf … vmu_save_*.bin` glob misses and the client's
+  allowlist (`vmu_save_[A-D][12].bin`) rejects. The sync then silently
+  ships an incomplete card and the only symptom is "Peer verification
+  failed" with no hint as to why.
+- A shared `<rom basename>.state.net` savestate is still honored by
+  flycast when present (auto-loaded at start, its MD5 replaces the
+  VMU/flash hash — `emulator.cpp:674`, `ggpo.cpp:541`) but is no longer
+  needed by the pak's own flow.
+- GGPO forces the SH4 clock to stock 200 MHz and, under threaded rendering,
+  disables framebuffer emulation (`emulator.cpp:864,983`) — automatic.
+- GGPO disconnects a peer after 3 s of silence (`ggpo.cpp:566`) — opening
+  the overlay menu (pause) or save/load state mid-session will drop or
+  desync the match. Both sides launch the same game and sync from boot.
+- `GGPOAnalogAxes` must match on both peers (default 0 on both; digital-only
+  fighters like MvC2 don't need it).
+
+**DCNet** (`DCNet = yes`, overlay: "DCNet Online") — emulates the DC modem
+(or BBA with `EmulateBBA = yes`) and tunnels PPP/Ethernet traffic to the
+public `dcnet.flyca.st` relay, which routes to fan-run revival servers. This
+is for games with *native* online modes (PSO, ChuChu Rocket, Quake III,
+Alien Front Online, …), needs internet (not just LAN), needs no peer
+config, and does nothing for games without an online menu (MvC2). Off by
+default; independent of GGPO.
+
+Existing installs are already `.initialized`, so they never receive the
+newly seeded `[network]` block — that's fine: the overlay toggles create
+their keys through cfgdb on first save, and launch.sh creates/updates the
+`server =` and `EnableUPnP` lines itself (the latter on every GGPO launch,
+which is the only way an upgraded install ever gets it). The same is true of
+`[input] device2`: flycast drops keys left at their default when it
+rewrites the cfg, so a live file routinely has no `[input]` section at all
+— launch.sh creates the section and the key when it needs them.
+
 ## Runtime libraries
 
 **Nothing is shipped in the pak.** Verified on the Brick (tg5040) via

--- a/workspace/all/other/flycast/README.md
+++ b/workspace/all/other/flycast/README.md
@@ -643,335 +643,230 @@ Accepted as v1 behavior.
 Flycast v2.6 ships two unrelated online mechanisms; both are compiled into
 our binaries already (GGPO builds unconditionally under `if(NOT LIBRETRO)`,
 `CMakeLists.txt`; DCNet is `core/network/dcnet.cpp`). No patch changes were
-needed — the overlay's `Netplay` section (`overlay_settings.json`) plus the
-seeded `[network]` block in the `default-*.cfg` files are the entire
-integration.
+needed for either — flycast's own netplay code is used entirely as upstream
+built it.
 
-**GGPO** — rollback netplay between two flycast instances running the same
-game (Dreamcast console games included — `ggpo.cpp` has an explicit console
-path). Peers sync inputs over **UDP 19713** and re-simulate on rollback.
-Config lives in `emu.cfg` `[network]`:
+**Entry point (2026-07-29 rewrite):** GGPO netplay is no longer a persistent
+overlay toggle. It's a per-launch choice: press `Y` on a netplay-capable ROM
+in the game list (Phase 1 ships the capability marker only in DC.pak), or
+use the "Launch with Netplay" context-menu item — both do the same thing,
+the menu item just being the discoverable path. A plain `A` press on the
+same ROM is always an ordinary single-player launch: GGPO is never armed by
+accident and never outlives a quit. (Root Search moved from `Y` to `START`
+to make room for this.) Everything interactive — role, hotspot/WiFi, peer
+discovery, save sync — now lives in a new standalone wizard, `netplay.elf`
+(`workspace/all/netplay-wizard/`), that `DC.pak/launch.sh` runs before
+flycast starts. Design:
+`docs/superpowers/specs/2026-07-29-netplay-prelaunch-wizard-design.md`.
 
-```ini
-[network]
-GGPO = yes          # overlay: "GGPO Netplay"
-ActAsServer = yes   # host/P1 on one device, no (join/P2) on the other
-GGPODelay = 0       # overlay: "Input Delay" — 2-3 trades latency for fewer rollback hitches
-server = 192.168.x.x  # auto-written by launch.sh discovery; manual fallback only
-EnableUPnP = no     # forced by launch.sh on every GGPO launch (see below)
+### The wizard flow
+
+```
+netplay.elf --game <name> [--serve-dir <dir>] [--fetch-to <dir>]
+            [--fetch-files <pat,pat>] [--session-file <path>]
+netplay.elf --cleanup [--session-file <path>]
 ```
 
-Constraints, all verified in source:
-- The handshake exchanges MD5s of **BIOS + game + flash/VMU state**
-  (`ggpo.cpp:537`) and fails with "Peer verification failed" on mismatch.
-  launch.sh automates the state match ("host brings the memory card"):
-  the host plays on its **real** VMU/flash and serves a tar of exactly
-  the hashed files (`vmu_save_*.bin` + `dc_nvmem.bin`, hashed per
-  `maple_cfg.cpp:381` / `nvmem.cpp:267`) over a small HTTP server on
-  **TCP 19714** — busybox `httpd` where the firmware provides it
-  (tg5040), `python3 -u -m http.server` on tg5050 (its busybox 1.35
-  lacks the httpd applet), fail-open if neither exists; the client
-  pulls it into an isolated `netplay-data/` dir
-  (`XDG_DATA_HOME` override) and plays on the borrowed copy, so the
-  client's real saves are never touched and whoever hosts contributes
-  their own unlocks. The host snapshots its card to `netplay-backup/`
-  (one-deep) before each session. Only `dc_boot.bin` and the CHD must
-  still be byte-identical on both cards by hand — BIOS and game images
-  are never synced.
-- IP setup is automatic too, and **symmetric**. GGPO is peer-to-peer, so
-  each side has to know the other's address (`ggpo.cpp:579-597`): an
-  empty `server =` makes flycast target loopback on `localPort ^ 1` —
-  `127.0.0.1:19712` from the host, `127.0.0.1:19713` from the client
-  (`ggpo.cpp:584-590`, `:808-811`) — and wait
-  forever on "Starting Network", which has no timeout — the modal's
-  Cancel button is the only way out (`gui.cpp:1286`). So **both** devices
-  serve a two-line `netplay-info` on **TCP 19714** (line 1 the ROM
-  filename with its extension stripped, line 2 the role, `host` or
-  `client`), and **both** scan the
-  LAN for a peer serving the same ROM in the *opposite* role: the ROM
-  line prevents cross-game pairing, the role line prevents two hosts (or
-  two clients) from pairing. Each side tries the stored `[network]
-  server =` first, but **only when the device holds a /24 lease and that
-  address falls inside it**. Two things follow. After moving to a
-  different network the stored address belongs to the old one and can
-  never answer, so it is skipped instead of burning ~3 s on a dead
-  probe. And on a **non-/24 lease** the subnet is never parsed at all —
-  the address is read with `sed -n 's|.*inet \([0-9.]*\)/24 .*|\1|p'`,
-  which matches nothing on a /16 or /23 — so there the stored address is
-  skipped *unconditionally*, not merely when the octets differ. A repeat
-  session on the same /24 with an unchanged DHCP lease still pairs
-  almost instantly. Otherwise it ping-sweeps its own /24 and probes the
-  `ip neigh` neighbors **concurrently** (one background probe per
-  candidate, results collected through a hits dir), so a pass costs a
-  fixed ~7 s — a 3 s settle after the sweep plus a 4 s collect, extended
-  only by the slowest straggler probe, each of which is bounded by the
-  fetch watchdog at 3 s — rather than ~1 s per reachable host. Scan time
-  no longer scales with how busy the LAN is.
+Screens: Host/Join → connection mode (Hotspot/WiFi) → network setup →
+rendezvous → handshake → optional save sync → "Go" (writes
+`/tmp/netplay_session`, exits 0). `B` backs out one screen at a time;
+backing out after network setup has already started tears that setup back
+down first — hotspot stopped, previous WiFi restored, rsyncd stopped —
+before the wizard exits. There is no path from a cancelled wizard into a
+fallback single-player launch anywhere, including inside `launch.sh`. Exit
+codes: `0` proceed with netplay, `1` user cancelled, `2` error (shown on the
+wizard's own screen for anything that happens once the UI is up; a CLI
+usage error — e.g. a missing `--game` — returns 2 *before* `GFX_init`, with
+only a stderr message and no screen, though this is practically
+unreachable since `launch.sh` always passes `--game`); `launch.sh` treats
+anything non-zero as "return to the game list, never start flycast".
 
-  Two details here are load-bearing, and the first real pair test failed
-  because neither was in place. Candidates are **deduplicated by MAC**
-  before probing: the sweep itself leaves an ARP entry for every address
-  it touched, and a router that answers ARP for unused addresses turns
-  that into hundreds of phantom neighbours sharing a handful of MACs
-  (measured on a home LAN: 22 entries before a sweep, 259 after, ~19 real
-  MACs). Probing all of them swamps a 4-core handheld and nothing
-  finishes inside the collect window. And `nx_fetch` names each download
-  with `mktemp` rather than the pid: in POSIX sh `$$` keeps the *parent*
-  shell's pid inside a subshell, so a pid-derived name is literally the
-  same file in every concurrent probe — one probe's cleanup deletes
-  another's payload, and a dead host can `cat` a live host's answer and
-  win the selection. Concurrency is what made both of these reachable;
-  neither could bite while probes ran serially. All of it is bounded by a
-  90 s wall-clock deadline. Whoever resolves a peer writes its IP back
-  to `server =`, which stays a manual fallback
-  for LANs where discovery fails — with one caveat on a non-/24 lease,
-  where the fast path never probes it: a hand-set `server =` is then
-  reached only if that host happens to sit in the `ip neigh` table, and
-  nothing sweeps to populate that table off a /24. flycast still reads
-  the hand-set value and can connect on it (launch.sh leaves it alone
-  when discovery finds nothing), but the client will not have pulled the
-  save tar — the GGPO connection and the state sync part ways there.
-  **Launch order does not matter** —
-  either device may start first, with any gap up to the deadline. On top
-  of this shared discovery, the host additionally serves the VMU/flash
-  tar and the client additionally pulls it. Every failure path fails open
-  into a normal launch so GGPO surfaces errors visibly.
-- A discovery long enough to be worth covering is no longer a silent
-  black screen. (A fast one still is, and correctly so — see the end of
-  this bullet.) While the netplay
-  block runs, launch.sh drives the already-shipped `show2.elf` in daemon
-  mode — resolved bare via `PATH`, exactly like the scripts' other helper
-  binaries, so nothing new was built. The opening "starting" message is
-  the daemon's own `--text=` argument (the FIFO does not exist yet at
-  that point); from there on launch.sh pushes `TEXT:` lines over
-  `/tmp/show2.fifo` at each stage: preparing saves (host, `TEXT:` only —
-  it carries no `PROGRESS:`, so no percentage is left standing in front
-  of the long wait that follows), looking for the peer — the host names
-  the `<subnet>.x` it is scanning, or "the network" when it holds no /24
-  lease to name — then peer found at `<ip>`, which on
-  the client is a **single** combined `host found at <ip> - copying
-  saves...` message rather than two updates (plain ASCII hyphen — a
-  tester matches these against the screen), or "starting anyway" when
-  nothing turned up. `PROGRESS:` rides along only where it means
-  something: `-1` (the marquee again) for the open-ended search, a real
-  percentage once a peer is resolved or the search has given up.
-  Sent is not the same as seen. Which message is on screen at any moment
-  is not something the design pins down: each write is *queued* from its
-  own background subshell polling for the FIFO on an independent 1 s
-  cadence, so any of the messages racing show2's init may end up the
-  survivor; and the terminal messages are followed immediately by a
-  `killall -9` that destroys the daemon, leaving them a frame at most. It
-  follows that the screen will ordinarily disappear still showing a
-  search message. The client's "copying saves" is the one update that is
-  reliably readable, because the tar fetch follows it — ~1-2 s for a
-  ~384 KB card over LAN (derived), the 30 s in `nx_fetch` being only the
-  watchdog ceiling for a host that stalls. Read the screen as evidence
-  that discovery is running, not as a progress transcript. And note the
-  corollary: on the repeat-session fast path the stored-`server =` probe
-  resolves in about a second, so the whole block can finish about as fast
-  as show2 comes up — expect a brief flash, or nothing at all. Either is
-  the feature working: there was barely a wait to cover. The screen
-  takes exactly **one** input — B skips netplay (next bullet), which is
-  why a second line sits under the status text — and is otherwise
-  informational: nothing else on it is interactive and it has no other
-  effect on what discovery does. It runs with
-  `--image=/dev/null` (there is no netplay artwork — the repo's existing
-  "no logo" idiom) and `--progress=-1`, show2's indeterminate marquee,
-  because the wait has no knowable length. `/dev/null` is accepted at
-  runtime: `IMG_Load` logs "not a regular file or pipe" and rendering
-  carries on (measured, Brick, 2026-07-29). show2 paints nothing until
-  its SDL2/DRM init finishes, and only creates its FIFO after that
-  (`mkfifo` is the first thing `runDaemonMode()` does after unlinking any
-  stale node) — **measured at ≤1 s** on tg5040 over three cold runs, so
-  only the first moment of a netplay launch is dark. Teardown must use
-  `killall -9`: show2 handles SIGINT only (`show2.cpp:623`) and `SDL_Init`
-  traps SIGTERM into an `SDL_QUIT` event its daemon loop never pumps, so
-  a plain `killall` leaves it running (measured alive 6 s later) and
-  holding the display against flycast. Everything
-  degrades silently: no `show2.elf` on `PATH`, or a daemon that died,
-  means no status screen and an otherwise-normal launch — exactly the
-  old silent behavior — and every FIFO write happens inside a background
-  subshell so a half-dead daemon can never stall the launch. Verified on
-  hardware at the function level only (start / update / stop / no-op when
-  absent, Brick 2026-07-29; the deployed tg5050 binary separately shown
-  to start, create its FIFO in ~1 s and take `TEXT:`/`PROGRESS:`
-  updates). No one has yet watched it driven by a real game launch on
-  either device.
-- **Press B during discovery to skip netplay — for that run only.** The
-  status screen's second line reads `B = skip netplay`, and pressing B
-  stops the search and launches the game single-player. The window is
-  the whole netplay block: `nx_cancel_arm` runs immediately after the
-  screen is started, before any network work, and the flag survives
-  until `nx_cancel_disarm` runs on the far side of the block, just
-  before flycast is started. It is checked at every phase boundary —
-  after the host has snapshotted and served its VMU tar, after the
-  client has published its identity, on entry to each discovery pass
-  and before each neighbour probe — and *inside* the network waits as
-  well: `nx_fetch`'s own watchdog polls it once a second, so a press
-  during the client's tar download (watchdog ceiling 30 s) is acted on
-  within about a second instead of after the download finishes. "Skip"
-  means **this run only**. launch.sh starts flycast with `-config
-  network:GGPO=no`; flycast stores a `-config` value as a **virtual**
-  setting — `get_entry()` prefers virtual values and `ConfigFile::save()`
-  never writes them (`cl.cpp` → `cfgSetVirtual`, `ini.cpp`) — so
-  `emu.cfg` is left untouched: `[network] GGPO` is still `yes`
-  afterwards and the next launch attempts netplay again. A cancelled
-  client also skips the `XDG_DATA_HOME` redirect, so it plays on its
-  **own** VMU rather than the host's borrowed copy (with GGPO off there
-  is nothing to isolate; its real saves were never at risk either way).
-  The screen shows `Skipped - starting game...` for a beat first — the
-  one-second pause on the cancel path exists only so that message can
-  be painted at all, since `nx_ui` merely *queues* its write and
-  `nx_ui_stop` kills the daemon two lines later; a press early enough to
-  precede show2's FIFO still cancels, it just cannot be confirmed on
-  screen. One residual: `[input] device2 = 0` is written unconditionally
-  at the top of the block and no cancel path reverts it, so it stays
-  until a launch with GGPO **off** puts it back to `10`.
-- How the press is read, and what the design deliberately leaves
-  behind. The hint line is show2's new **optional `--hint`** argument: a
-  second line drawn under the status text in `renderSimple()` — which
-  `renderProgress()` calls, so both display modes get it — and skipped
-  entirely when the argument is absent, so the first-boot install
-  splash, which is the same binary, renders exactly as before. B is js0
-  event **number `00`**, measured on **both** units — five consecutive
-  presses on each, every one type `01` number `00` with a non-zero
-  value, the Smart Pro S reading identical to the Brick — which agrees
-  with this pak's own `SDL_Xbox 360 Controller.cfg` (`bind0 =
-  0:btn_b`). So the one shared constant is right for both and the
-  byte-identical block needs no per-device handling. An earlier reading
-  of `02` came from a block-buffered reader that misattributed delayed
-  events and must not be restored.
-  The reader opens `/dev/input/js0` **once** on fd 3 and then runs one
-  short-lived `dd bs=8 count=1 <&3 | hexdump` per event, so hexdump
-  exits — and therefore flushes — every time. Both obvious alternatives
-  were tried on-device and fail: a persistent `dd | hexdump | while
-  read` pipeline block-buffers (~4 KB, ~170 events) and recorded zero
-  presses across a 45 s capture, and a `count=1` loop that re-opens the
-  device replays joydev's init burst on every pass and spins. Nothing
-  but a real press can trip it: the init burst is type 81/82 with value
-  0, releases carry value 0, and stick motion is type 02. If js0 is
-  unreadable the watcher exits at once and cancel is simply unavailable
-  — every other path is unchanged. Killing the watcher does **not**
-  reap its `dd`/`hexdump` children, and that leak is accepted on
-  purpose. It clears itself: the `dd` has `count=1`, so the first
-  controller event after the game starts ends it, hexdump then EOFs, and
-  joydev gives each opener an independent event buffer so nothing is
-  taken from flycast meanwhile. Both sweeps that would clean it up are
-  wrong — matching `/proc/<pid>/cmdline` cannot work (the device is a
-  redirection, never an argument; verified on-device to find none of the
-  holders), and matching open descriptors does find them all but "kill
-  whatever holds js0" would also hit `keymon.elf`, which opens input
-  devices for the whole session, or the launcher, and killing the
-  launcher powers this device off.
-- What has actually been tested (2026-07-29) — bench level, both
-  devices. The shipped helpers pass 12/12 checks on the Brick, run
-  against the functions extracted verbatim from launch.sh: arm/disarm
-  lifecycle, a stale flag cleared by `nx_cancel_arm`, the flag honoured,
-  and `nx_fetch` returning empty 2 s into a 30 s timeout when the flag
-  appears (the check that proves a press during the tar download is
-  acted on promptly). The rebuilt show2 was watched on hardware
-  rendering two lines, with the hint persisting across `TEXT:` updates
-  and the marquee animating, freezing on a numeric `PROGRESS:` and
-  re-arming on a later `PROGRESS:-1`; the no-`--hint` install-splash
-  invocation was unaffected. Both rebuilt binaries are now **deployed**
-  (Brick md5 `2678718c` → `4be3ac43`, Smart Pro S `fe7d510b` →
-  `c943d4b7`, each md5-verified against the local build, and `show2.elf`
-  resolves bare via `PATH` on both); the pre-change binary is kept
-  on-device as `show2.elf.orig` beside it, so rolling the shared install
-  splash back needs no computer. The deployed tg5050 copy was then run
-  with `--hint` on the Smart Pro S — a platform that had never run show2
-  at all — and starts, creates its FIFO in ~1 s, accepts `TEXT:` and
-  `PROGRESS:` updates and stays alive. **Not** tested, all three needing
-  a real session: an actual B press during a real game launch — that it
-  cancels, lands in single-player and leaves `[network] GGPO = yes`
-  afterwards — which cannot be driven over adb, since input cannot be
-  injected; any two-device pair test with the new block on both units;
-  and the cancelled-client-plays-on-its-own-saves path, which is
-  code-verified and reasoned but never exercised in a session.
-- Netplay launches also plug a controller into Dreamcast **port B**:
-  launch.sh sets `[input] device2 = 0` (`MDT_SegaController`) while GGPO
-  is on, automatically on both devices, and puts it back to `10`
-  (`MDT_None`) when GGPO is off, so single-player sessions see the stock
-  one-pad Dreamcast. GGPO **always drives port B as player 2** — the
-  remote player on the host, the *local* player on the client
-  (`ggpo.cpp:500`/`:569` set the local player to `localPlayerNum + 1`,
-  and `ggpo.cpp:643-650` writes `inputState[player]` straight to the
-  maple port index) — so both machines need a pad there. flycast leaves
-  port B empty by default (`option.cpp:197-201`, enum
-  `maple_cfg.h:6-18`), so those inputs reached no maple device at all —
-  MvC2's VS mode stayed greyed out and the second device's Start did
-  nothing (that device's *own* player is port B). **Both
-  peers must carry the identical value** or the emulated machines differ
-  and desync; that is why launch.sh owns the key on both sides rather
-  than leaving it to a hand edit. A bare controller on port B does not
-  perturb the GGPO verification digest — `vmuDigest()`
+Ports, all distinct from minarch's own in-game netplay (55435-55438,
+56400/56421) so the two can coexist during the migration described in
+`DEV_TODO.md`:
+
+- **TCP 55440** — wizard control channel (`HELLO`/`REJECT`/`SYNC-READY`/
+  `SYNC-DONE`/`START`, line-based).
+- **UDP 55441** — discovery broadcast, magic `NXWZ` (`0x4E58575A`), sent
+  once a second while a host waits. A client only ever lists hosts
+  broadcasting the *identical* game name, so wrong-game pairing is
+  impossible by construction rather than a stall to diagnose after the
+  fact. The `HELLO` handshake re-checks the game name and protocol version
+  anyway, but only the CLIENT ever sees a mismatch: a rejected client shows
+  the named reason and falls back to its host list (WiFi) or exits the
+  wizard (hotspot has no other host to fall back to). The HOST shows no
+  error at all — it sends `REJECT` and simply keeps showing "Waiting for
+  player...", by design (`wizard_net.c`: "rejecting is not an error here —
+  the host keeps waiting for the peer it is actually paired with").
+- **TCP 18731** — the save-sync rsync daemon below. Deliberately not
+  Device Sync's 18730, so the two features' daemons never collide.
+
+### Save sync: rsync daemon, replacing tar + a per-platform HTTP server
+
+The host starts a read-only rsync daemon for the length of the handshake
+only (config written to `/tmp/netplay_rsyncd.conf`: one module named `sync`
+mapped to `--serve-dir`, `read only = true`, `hosts allow = <client ip>`,
+`list = false`, port 18731) and sends `SYNC-READY`; the client pulls each
+`--fetch-files` pattern with `rsync rsync://<host>:18731/sync/<pattern>`
+into a staging directory inside `--fetch-to`, showing a progress bar parsed
+from `--info=progress2`. Only once the WHOLE requested set has landed does
+the client rename it into `--fetch-to` proper (same filesystem, so each
+commit is an atomic `rename()`) — a failure partway removes the staging
+directory instead of leaving a partial card in place, which is what the old
+five-condition tar guard existed to prevent. The daemon is stopped the
+moment `SYNC-DONE` comes back, so it lives seconds, not the length of the
+match. Filenames are treated as data end to end — whitelisted to
+`[A-Za-z0-9._-]+` on both the wire protocol and the rsyncd module, never
+shell-interpolated — which is what now does the anti-traversal /
+anti-shell-metacharacter job the old tar guard did.
+
+### Virtual config — nothing persists to `emu.cfg`
+
+`launch.sh` starts flycast with every netplay value as a **virtual**
+`-config`, `GGPO`/`ActAsServer`/`server`/`EnableUPnP`, plus (now
+unconditionally) `input:device2`:
+
+```sh
+-config network:GGPO=yes -config network:ActAsServer=$NX_AS_SERVER \
+-config network:server=$NETPLAY_PEER_IP -config network:EnableUPnP=no \
+-config input:device2=0
+```
+
+flycast's `get_entry()` prefers a virtual value over the one in the file,
+and `ConfigFile::save()` never writes a virtual value back (`cl.cpp` →
+`cfgSetVirtual`, `ini.cpp`) — the same mechanism the old flow's B-skip
+already relied on for one value, now used for the whole netplay path.
+`emu.cfg` is never touched by a netplay run. `GGPODelay` and `DCNet`
+remain real, persisted overlay keys — ordinary gameplay settings a player
+wants to keep between sessions — while `GGPO` and `ActAsServer` were
+removed as overlay items entirely (`overlay_settings.json`'s `Netplay`
+section now ships only `GGPODelay` + `DCNet`): there is no in-game toggle
+for netplay any more.
+
+**Migration guard** (idempotent, runs on every DC launch before the netplay
+gate): if `[network] GGPO` is `yes`/`True`, set it to `no`; if
+`[input] device2` is `0`, set it to `10`. This is what makes a plain launch
+on a card that ran the old overlay-toggle flow immediately sane again — no
+90 s peer wait on what the player intends as a single-player session.
+Known, accepted ambiguity: a user who hand-set `device2 = 0` in flycast's
+own Controls UI for local two-pad play has it reverted the one time the
+old value is still on disk; the new flow never writes `device2` back to
+`emu.cfg` at all, so it cannot recur after that. A stale `server =` (or
+`EnableUPnP = no`) left over from an old session is harmless and
+deliberately not swept — flycast only reads it on the GGPO path, where the
+wizard's virtual value overrides it anyway.
+
+### Cleanup and self-heal
+
+`launch.sh` calls `netplay.elf --cleanup` after `wait $EMU_PID`, gated on
+the session file's presence: stop any stray rsyncd, tear down a hotspot AP
+and restore the WiFi network that was active before it (persisted as
+`NETPLAY_PREV_SSID` in the session file, since a fresh `--cleanup` process
+can't inherit `wifi_direct.c`'s in-memory previous-network state across
+processes), then remove the session file. Bounded to a 19 s budget
+(`WIZ_TEARDOWN_BUDGET_MS`, `wizard.c`) even against a slow supplicant
+reconnect. The wizard also runs this same teardown defensively at its own
+startup whenever a stale session file exists — a pak killed mid-session
+(an OSD/power quit bypasses `launch.sh`'s own exit block entirely) is
+healed the next time netplay is attempted, rather than left as an orphaned
+AP indefinitely.
+
+### What this replaced, and why (superseded 2026-07-29)
+
+The previous flow was a shell implementation of everything above, built
+2026-07-28/29 and largely never pair-tested. Every piece below maps to
+something in the wizard that is both simpler and already proven in-repo.
+Full mechanics and the reasoning behind them (still useful for
+archaeology) live in `docs/superpowers/specs/2026-07-28-netplay-state-sync-design.md`,
+`2026-07-28-netplay-discovery-feedback-design.md`, and
+`2026-07-29-netplay-cancel-discovery-design.md`.
+
+- **Ping-sweep discovery** (`nx_find_peer`: sweep the local /24, dedup by
+  MAC, probe `ip neigh` concurrently, bounded by a 90 s deadline) → UDP
+  broadcast reaches the peer directly. The ARP-storm bug class this fought
+  (a router answering ARP for every unused address turned 22 neighbours
+  into 259 across one sweep on a home LAN) is structurally gone, not
+  merely patched around.
+- **Tar over a platform-divergent HTTP server** (busybox `httpd` on
+  tg5040, `python3 -u -m http.server` on tg5050 because its busybox 1.35
+  has no `httpd` applet) plus five hand-rolled tar-slip guards → the rsync
+  daemon above, one implementation on both platforms.
+- **`show2.elf`'s FIFO-driven status screen** (`TEXT:`/`PROGRESS:` over
+  `/tmp/show2.fifo`, racing its own init against launch.sh's writes) → the
+  wizard's own real screens — a host/join menu, a live host list, a
+  progress bar, named errors instead of a message that may or may not
+  have been queued in time. `show2.elf` is no longer part of netplay at
+  all; it remains only the first-boot install splash.
+- **Pressing B mid-discovery to fall through to a single-player launch for
+  that run only** → `B` now backs the wizard out entirely (tearing down
+  anything already set up) and returns to the game list; there is no
+  fallback path into a peerless GGPO launch any more.
+- **The `js0` hexdump B-cancel reader** (`dd bs=8 count=1 <&3 | hexdump`,
+  one child process per poll) → ordinary SDL input handling inside the
+  wizard, the same as every other NextUI screen.
+
+### flycast internals unaffected by the rewrite (still true)
+
+None of this changed — it's how flycast itself behaves, independent of
+what drives it:
+
+- The handshake exchanges MD5s of **BIOS + game + flash/VMU state**
+  (`ggpo.cpp:537`) and fails with "Peer verification failed" on mismatch —
+  which is why the host still plays on its real VMU/flash ("host brings
+  the memory card") and the client plays on a synced, isolated copy rather
+  than its own. Only `dc_boot.bin` and the CHD must still be
+  byte-identical on both cards by hand — BIOS and game images are never
+  synced.
+- An empty `server =` makes flycast target loopback on `localPort ^ 1`
+  (`ggpo.cpp:579-597,808-811`) and wait forever on "Starting Network",
+  which has no timeout — the modal's Cancel button is the only way out
+  (`gui.cpp:1286`). The wizard always resolves a real peer IP before
+  starting flycast, so this should now only be reachable through a truly
+  exotic failure.
+- GGPO **always drives Dreamcast port B as player 2** — the remote player
+  on the host, the *local* player on the client (`ggpo.cpp:500`/`:569` set
+  the local player to `localPlayerNum + 1`, and `ggpo.cpp:643-650` writes
+  `inputState[player]` straight to the maple port index) — and flycast
+  leaves port B empty by default (`option.cpp:197-201`, enum
+  `maple_cfg.h:6-18`), so both machines need a pad there or the second
+  device's own inputs reach no maple device at all (MvC2's VS mode
+  greyed out, the second device's Start doing nothing). **Both peers must
+  carry the identical value** or the emulated machines differ and desync
+  — which is why `launch.sh` sets it as a virtual value on both sides
+  rather than leaving it to a hand edit. A bare controller on port B does
+  not perturb the GGPO verification digest — `vmuDigest()`
   (`maple_cfg.cpp:364`) only hashes devices whose `getData()` is
   non-null.
-- Security posture: the rendezvous is deliberately unauthenticated
-  (home-LAN scope). While netplay is on, the serve dir is readable by
-  any device on the network for the session's duration — on the host
-  that is the `netplay-info` identity file plus the VMU/flash tar, on
-  the client only `netplay-info` (the python3 branch also
-  directory-indexes the dir; the server writes no request log at all —
-  busybox `httpd` runs without `-v` — and the stdout/stderr file it does
-  write lives outside the serve dir, so nothing there is served). Note
-  what that tar actually contains: `data/flycast` is shared by **all**
-  Dreamcast games, so the host serves its **entire VMU set** (every
-  `vmu_save_*.bin` plus `dc_nvmem.bin`), not just the saves of the game
-  being played. Outbound, every netplay-on launch **ping-sweeps all 254
-  addresses of the local /24 repeatedly and HTTP-GETs each neighbor**
-  for up to 90 s; on a network that is not your own home LAN that
-  traffic reads as a port scan. Inbound, the client
-  extracts a synced tar only when all **five** guard conditions hold:
-  the file is non-empty; `tar tf` lists at least one entry (a non-tar
-  payload lists nothing, which would pass every negated test
-  vacuously); every name is a bare allowlisted filename (no slashes,
-  no `..`, no absolute paths); every `tar tvf` mode column is `-`; and
-  no entry is a link (` -> `). The link test is not redundant with the
-  mode column: busybox tar prints a HARDLINK with a leading `-`, so on
-  this firmware the mode column alone would accept one. Verdicts on
-  device (Brick, busybox 1.27.2): good tar ACCEPT; path-traversal,
-  symlink, hardlink, non-tar junk and empty all REJECT. A hostile peer
-  can at worst replace the client's netplay-data VMU copies, never
-  write outside them.
-- **UPnP is forced off** on every GGPO launch: launch.sh writes
-  `[network] EnableUPnP = no`. flycast defaults it to **true**
-  (`option.cpp:172`) and `ggpo.cpp:801-804` runs `miniupnp.Init()` +
-  `AddPortMapping(19713/UDP)` *before* the `ActAsServer` branch, so
-  **both** roles would otherwise punch a router mapping with an 86400 s
-  lease (`miniupnp.cpp`). The `EnableUPnP = no` seeded in the
-  `default*.cfg` files only reaches **fresh installs** (they're gated
-  behind `.initialized`), so writing it from launch.sh is what closes it
-  on already-installed devices. There is no restore-when-off branch —
-  the value is only read on the GGPO path.
-- **Pairing key gotcha:** peers match on the ROM **filename with its
-  extension stripped** (`EMU_OVERLAY_GAME`), *not* on CHD content. Two
-  byte-identical CHDs stored under different filenames will never pair,
-  and the symptom is thin: the status screen sits for the full 90 s on
-  whatever message survived show2's init window — "looking for the host"
-  on the client, either "preparing saves" or "looking for player 2 …" on
-  the host — then simply
-  disappears, because the "starting anyway" update is queued and killed
-  before it can be read. flycast then drops into its untimed "Starting
-  Network". Nothing names the mismatch. Keep the game file named
-  identically on both cards.
+- **UPnP is forced off** because `ggpo.cpp:801-804` runs
+  `miniupnp.Init()` + `AddPortMapping(19713/UDP)` **before** the
+  `ActAsServer` branch, so both roles would otherwise punch a router
+  mapping with an 86400 s lease (`miniupnp.cpp`). `EnableUPnP = no` is one
+  of the virtual `-config` values above on every netplay launch now,
+  rather than a value `sed`-written into `emu.cfg`; there is still no
+  restore-when-off branch, since the value is only ever read on the GGPO
+  path.
+- **Pairing key is the ROM filename with its extension stripped**
+  (`EMU_OVERLAY_GAME`), not CHD content — two byte-identical CHDs stored
+  under different filenames will never pair. The wizard's discovery-list
+  filtering and `HELLO` mismatch check are both keyed on this same
+  string, so keep the game file named identically on both cards.
 - **Leave flycast's `PerGameVmu` off.** With it on, the port-A1 VMU file
   is written as `<gameId>_vmu_save_A1.bin` (`oslib.cpp:52-66`) — a name
-  the host's `tar cf … vmu_save_*.bin` glob misses and the client's
-  allowlist (`vmu_save_[A-D][12].bin`) rejects. The sync then silently
-  ships an incomplete card and the only symptom is "Peer verification
-  failed" with no hint as to why.
+  the wizard's `--fetch-files` glob (`vmu_save_*.bin`) does not match, any
+  more than it matched the old tar glob. The sync then silently ships an
+  incomplete card, with "Peer verification failed" the only symptom.
 - A shared `<rom basename>.state.net` savestate is still honored by
   flycast when present (auto-loaded at start, its MD5 replaces the
-  VMU/flash hash — `emulator.cpp:674`, `ggpo.cpp:541`) but is no longer
-  needed by the pak's own flow.
-- GGPO forces the SH4 clock to stock 200 MHz and, under threaded rendering,
-  disables framebuffer emulation (`emulator.cpp:864,983`) — automatic.
+  VMU/flash hash — `emulator.cpp:674`, `ggpo.cpp:541`), independent of the
+  wizard's own sync.
+- GGPO forces the SH4 clock to stock 200 MHz and, under threaded
+  rendering, disables framebuffer emulation (`emulator.cpp:864,983`) —
+  automatic.
 - GGPO disconnects a peer after 3 s of silence (`ggpo.cpp:566`) — opening
   the overlay menu (pause) or save/load state mid-session will drop or
   desync the match. Both sides launch the same game and sync from boot.
-- `GGPOAnalogAxes` must match on both peers (default 0 on both; digital-only
-  fighters like MvC2 don't need it).
+- `GGPOAnalogAxes` must match on both peers (default 0 on both;
+  digital-only fighters like MvC2 don't need it).
 
 **DCNet** (`DCNet = yes`, overlay: "DCNet Online") — emulates the DC modem
 (or BBA with `EmulateBBA = yes`) and tunnels PPP/Ethernet traffic to the
@@ -979,16 +874,16 @@ public `dcnet.flyca.st` relay, which routes to fan-run revival servers. This
 is for games with *native* online modes (PSO, ChuChu Rocket, Quake III,
 Alien Front Online, …), needs internet (not just LAN), needs no peer
 config, and does nothing for games without an online menu (MvC2). Off by
-default; independent of GGPO.
+default; independent of GGPO; entirely unaffected by the wizard rewrite.
 
-Existing installs are already `.initialized`, so they never receive the
-newly seeded `[network]` block — that's fine: the overlay toggles create
-their keys through cfgdb on first save, and launch.sh creates/updates the
-`server =` and `EnableUPnP` lines itself (the latter on every GGPO launch,
-which is the only way an upgraded install ever gets it). The same is true of
-`[input] device2`: flycast drops keys left at their default when it
-rewrites the cfg, so a live file routinely has no `[input]` section at all
-— launch.sh creates the section and the key when it needs them.
+Existing installs are already `.initialized`, so they never receive a
+re-seeded `[network]` block from a fresh `default*.cfg` — that's fine: the
+migration guard above is what an upgraded card actually needs (it runs on
+every launch, not just first-run), and since the netplay values are all
+virtual now, nothing about `emu.cfg` needs to change on an upgraded card at
+all. Existing installs still routinely have no `[input]` section (flycast
+drops keys left at default when it rewrites the file), but that no longer
+matters either, since `device2` is virtual-only on the netplay path.
 
 ## Runtime libraries
 

--- a/workspace/all/other/flycast/README.md
+++ b/workspace/all/other/flycast/README.md
@@ -885,6 +885,122 @@ all. Existing installs still routinely have no `[input]` section (flycast
 drops keys left at default when it rewrites the file), but that no longer
 matters either, since `device2` is virtual-only on the netplay path.
 
+## Pre-launch options (Emulator Options / Emulator Settings)
+
+Flycast's `emu.cfg` keys can be set **before** a game starts, without opening
+the in-game overlay, through two entry points that share one schema. **Per-game
+overrides** come from the game-list context menu's "Emulator Options" item —
+shown only when a pak beside the ROM's `launch.sh` also ships an `options.sh`
+probe. **Global defaults** come from Tools → Emulator Settings, which runs
+`options.elf --pick`. Both edit the same shared schema,
+`overlay_settings.json` (the very file the in-game Options screen reads, above),
+so a key is described in exactly one place. A per-game edit is written to its own
+file at
+`$SHARED_USERDATA_PATH/DC-flycast/config/<device>/games/<key>.cfg`, where `<key>`
+comes from `nx_rom_base()` — a folder-named `.m3u` game collapses to the folder
+name. At launch, `launch.sh` turns any present per-game file into virtual
+`-config` arguments (`$GAME_ARGS`) placed **before** `$NETPLAY_ARGS`, i.e. the
+same last-`-config`-wins mechanism the netplay path above uses. Setting
+`EMU_OVERLAY_HIDE_OPTIONS=1` hides the in-game Options menu for that launch.
+Design: `docs/superpowers/specs/2026-07-29-dc-prelaunch-options-design.md`.
+
+### Override precedence and the argv contract
+
+- **Override precedence is argv order, not sections.** `launch.sh` runs
+  `./flycast $GAME_ARGS $NETPLAY_ARGS "$ROM"`, and flycast's last `-config` for a
+  repeated `section:key` wins: `ParseCommandLine()` walks argv left-to-right
+  (`core/cfg/cl.cpp`) and each `-config` lands in `cfgSetVirtual()` →
+  `ConfigSection::set()`, a plain `std::map` assignment (`core/cfg/ini.cpp`).
+  Swapping the two variables silently inverts netplay precedence, so `GAME_ARGS`
+  stays first and `NETPLAY_ARGS` last.
+- **Both arg variables are deliberately unquoted** — they are word-split argument
+  lists whose values are ints/bools with no whitespace, and empty on a normal
+  launch. A schema that ever grew a string-valued option would break this; it
+  would need a different mechanism, not quoting.
+- **Bools are written `True`/`False`, not `yes`/`no`.**
+  `emu_ovl_cfg_format_value` speaks flycast's INI dialect and both spellings
+  parse fine, so don't "fix" an override file that reads `rend.WideScreen = True`
+  — and don't grep argv for `=yes`; the pair to expect there is
+  `-config config:rend.WideScreen=True`. The single spaces around `=` in the
+  override file ARE load-bearing: `launch.sh`'s awk splits on `-F' = '`, so a
+  hand-edited `key=value` line is silently dropped.
+
+### Debugging: argv is the only witness
+
+- **Applied overrides leave NO trace in `$LOGS_PATH/DC.txt` — don't look for
+  one.** flycast does log every virtual pair (`Virtual cfg <sec>:<key>=<val>`,
+  `core/cfg/cl.cpp:51`) but that call is an `INFO_LOG`, and INFO level is
+  compiled **out** of Release builds (`MAX_LOGLEVEL` = `LWARNING` under `NDEBUG`,
+  `core/log/Log.h:58-63`; the paks are built `-DCMAKE_BUILD_TYPE=Release`).
+  Verified against the shipped binaries: `strings` finds zero `Virtual cfg`
+  occurrences in either `DC.pak/flycast`, while NOTICE-level log strings from the
+  same builds are present. This is the same trap `flycast.patch:110-112` already
+  documents for the audio path. **The witness is argv**, not the log:
+  `tr '\0' ' ' < /proc/$(pidof flycast)/cmdline` (or `xargs -0 echo <` the same
+  file) shows every `-config` pair and, crucially, their order — the same applies
+  to netplay's six pairs. Read `/proc` directly rather than reaching for `ps w`:
+  the device's busybox `ps` only honors `w` when built with `FEATURE_PS_WIDE`,
+  and without it argv is truncated to the terminal width, silently hiding the
+  very `-config` pairs you're looking for.
+- **Never run `DC.pak/launch.sh` (or `options.sh`) from a bare adb shell to see
+  what path it computes.** Both source `nx_paths.sh`, which builds every path
+  from `SHARED_USERDATA_PATH` and branches on `DEVICE` — and those are exported by
+  `MinUI.pak/launch.sh` (`:23`, `:52-56`), not by the pak itself. Outside
+  nextui's environment they're empty/unset, so the pak resolves
+  `$DEVICE_CONFIG_DIR` to a bogus
+  **`/DC-flycast/config/tg5040-smart-pro/…`** on the rootfs (empty prefix,
+  `DEVICE` falling through to the smart-pro `else`), happily `mkdir`s it and seeds
+  a junk `emu.cfg` there. `SDCARD_PATH` being empty also breaks
+  `LD_LIBRARY_PATH`, `EMU_OVERLAY_JSON` and `FLYCAST_BIOS_PATH`, so the run is not
+  a faithful launch either. Only the trailing `<key>.cfg` basename would be
+  trustworthy from such a trace. If you genuinely need to trace the pak, export
+  the environment first — `skeleton/SYSTEM/tg5040/dbg/launch.sh:3-27` is the
+  ready-made export list (note it leaves `DEVICE` unset on Smart Pro, where
+  `nx_paths.sh`'s `else` happens to land correctly).
+
+### File format and lifecycle edge cases
+
+- **A malformed or unreadable override file is skipped silently** — the game
+  launches with globals only, no error anywhere, and (per the debugging note
+  above) nothing in the log either way. If an override "doesn't apply", dump
+  argv: pair absent → `launch.sh` never parsed the file (wrong filename, or a
+  line not matching `key = value`); pair present but no visible effect → flycast
+  took the value and something else is wrong. The editor treats a malformed file
+  as empty and rewrites it cleanly on the next save.
+- **The override key can collide by design.** `nx_rom_base()` maps a folder-m3u
+  game to the folder name, so a flat ROM that happens to share that name resolves
+  to the same override file. Inherent to the mandated one-file-per-game scheme,
+  accepted.
+- **Renaming or deleting a ROM orphans its override file** — harmless, and
+  deliberately not cleaned up (explicit non-goal). It will silently re-attach if
+  a ROM with the old name ever reappears.
+
+### The editor binary (`options.elf`)
+
+- **`options.elf` is a SYSTEM bin on `PATH`, invoked bare** — same shape as
+  `netplay.elf`. Pushing a rebuilt copy needs no reboot (it is not
+  nextui/minarch), but the editor must not be running at the time.
+- **`options.sh`'s stdout must stay uncaptured.** Only stderr is redirected (to
+  `$LOGS_PATH/emu-options.txt`); the Emulator Settings tool captures
+  `options.elf --pick`'s stdout **directly** and `exec`s the result, so wrapping
+  `options.sh` in `$(…)` anywhere would swallow the editor's own output stream.
+  This is the same class of bug the tg5050 fancontrol lesson taught: a
+  `system("… &")` daemon (the fan-control daemon respawned by `InitSettings()`)
+  inherited the picker's `$()` pipe write end and hung the capture, because the
+  pipe stays open as long as any process holds its write end. `options.c` now
+  parks stdout with `FD_CLOEXEC` (`stdout_park`) for exactly this reason, so a
+  daemon a child spawns can never keep the capture pipe open.
+- **Editor exit 1 means two different things** — cancel in `--pick` mode,
+  config-load failure in the edit modes; a plain usage error exits 2. Callers
+  must not conflate the two exit-1 cases (they currently don't: `options.sh`
+  ignores the edit-mode code, the tool treats empty stdout as cancel).
+- **Emulator Settings exits silently (rc=0) when no pak on the card ships an
+  `options.sh`** — an empty Tools app, not an error. Expected on any platform
+  other than tg5040/tg5050, where `options.elf` isn't even built.
+- The schema's `options_hint` still reads "Restart game to apply changes" —
+  correct for the in-game overlay, vacuous in the pre-launch editor (nothing is
+  running yet). Cosmetic; left alone so both consumers share one schema file.
+
 ## Runtime libraries
 
 **Nothing is shipped in the pak.** Verified on the Brick (tg5040) via

--- a/workspace/all/show2/show2.cpp
+++ b/workspace/all/show2/show2.cpp
@@ -40,6 +40,7 @@ constexpr int PROGRESS_BAR_WIDTH = 400;
 constexpr int TEXT_PADDING = 20;
 constexpr int LOGO_TEXT_PADDING = 40;
 constexpr int FONT_SIZE = 24;
+constexpr int HINT_GAP = 8;   // Pixels between the status line and the hint
 constexpr int FPS = 60;
 
 enum class DisplayMode {
@@ -54,6 +55,7 @@ struct Config {
     uint32_t bg_color_rgb = 0x000000;
     uint32_t font_color_rgb = 0xFFFFFF;
     std::string text;
+    std::string hint;         // Optional second line under the status text
     int progress = 0;
     int text_y_pct = 80;      // Text Y position as percentage of screen height
     int progress_y_pct = 90;  // Progress bar Y position as percentage of screen height
@@ -367,6 +369,27 @@ private:
                 SDL_FreeSurface(text_surface);
             }
         }
+
+        // Optional second line, drawn under the status text. Absent --hint
+        // this block is skipped entirely, so existing callers -- notably
+        // the first-boot install splash in install/boot.sh -- render
+        // exactly as they did before. renderProgress() calls this function,
+        // so both display modes are covered.
+        if (font && !config.hint.empty()) {
+            SDL_Surface* hint_surface = TTF_RenderUTF8_Blended(font, config.hint.c_str(), font_color);
+            if (hint_surface) {
+                int hint_y = (screen->h * current_text_y_pct) / 100
+                             + config.font_size + HINT_GAP;
+                SDL_Rect hint_dst = {
+                    (screen->w - hint_surface->w) / 2,
+                    hint_y,
+                    hint_surface->w,
+                    hint_surface->h
+                };
+                SDL_BlitSurface(hint_surface, nullptr, screen, &hint_dst);
+                SDL_FreeSurface(hint_surface);
+            }
+        }
     }
 
     void renderProgress() {
@@ -537,6 +560,7 @@ void printUsage() {
     std::cout << "                 [--logoheight=N] [--fontsize=24] [--timeout=N]\n";
     std::cout << "  Daemon mode:   show2.elf --mode=daemon --image=<path> [--bgcolor=0x000000] [--fontcolor=0xFFFFFF]\n";
     std::cout << "                 [--text=\"message\"] [--texty=80] [--progressy=90] [--logoheight=N] [--fontsize=24]\n";
+    std::cout << "                 [--hint=\"second line\"]\n";
     std::cout << "\n";
     std::cout << "Position parameters (texty, progressy) are percentages of screen height (0-100)\n";
     std::cout << "Default positions: texty=80, progressy=90\n";
@@ -614,6 +638,10 @@ int main(int argc, char* argv[]) {
 
     if (args.find("fontsize") != args.end()) {
         config.font_size = std::stoi(args["fontsize"]);
+    }
+
+    if (args.find("hint") != args.end()) {
+        config.hint = args["hint"];
     }
 
     // Create and run app


### PR DESCRIPTION
Adds two pre-launch features for Dreamcast (Flycast):

## Netplay wizard
- Y-button launch flow with host/join roles and GGPO config rewrite
- Peer discovery over hotspot (10.0.0.1/24) or shared wifi, with orphan-AP self-heal
- Save/VMU sync between devices via rsync before launch
- B-button cancellation at every step

## Options editor
- Per-game and global emulator option overrides (`emu.cfg`), editable from the game context menu
- Multi-disc (.m3u) and folder-game support with correct config keying
- Fresh-card seeding with idempotent defaults (`.initialized` guard)